### PR TITLE
Add support for reading stored message body in MIME format.

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -39,6 +39,7 @@ type DNSRecord struct {
 	Priority   string
 	RecordType string `json:"record_type"`
 	Valid      string
+	Name       string
 	Value      string
 }
 

--- a/mailgun.go
+++ b/mailgun.go
@@ -287,5 +287,5 @@ func parseMailgunTime(ts string) (t time.Time, err error) {
 
 // formatMailgunTime translates a timestamp into a human-readable form.
 func formatMailgunTime(t *time.Time) string {
-	return t.Format("Mon, 2 Jan 2006 15:04:05 MST")
+	return t.Format("Mon, 2 Jan 2006 15:04:05 -0700")
 }

--- a/mailgun.go
+++ b/mailgun.go
@@ -151,6 +151,7 @@ type Mailgun interface {
 	GetComplaints(limit, skip int) (int, []Complaint, error)
 	GetSingleComplaint(address string) (Complaint, error)
 	GetStoredMessage(id string) (StoredMessage, error)
+	GetStoredMessageRaw(id string) (StoredMessageRaw, error)
 	DeleteStoredMessage(id string) error
 	GetCredentials(limit, skip int) (int, []Credential, error)
 	CreateCredential(login, password string) error

--- a/messages.go
+++ b/messages.go
@@ -3,9 +3,10 @@ package mailgun
 import (
 	"encoding/json"
 	"errors"
-	"github.com/mbanzon/simplehttp"
 	"io"
 	"time"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 // MaxNumberOfRecipients represents the largest batch of recipients that Mailgun can support in a single API call.
@@ -619,8 +620,9 @@ func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 	return response, err
 }
 
-// GetStoredMessage retrieves information about a received e-mail message.
-// This provides visibility into, e.g., replies to a message sent to a mailing list.
+// GetStoredMessageRaw retrieves the raw MIME body of a received e-mail message.
+// Compared to GetStoredMessage, it gives access to the unparsed MIME body, and
+// thus delegates to the caller the required parsing.
 func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
 	r := simplehttp.NewHTTPRequest(url)

--- a/messages.go
+++ b/messages.go
@@ -76,6 +76,14 @@ type StoredAttachment struct {
 	ContentType string `json:"content-type"`
 }
 
+type StoredMessageRaw struct {
+	Recipients string `json:"recipients"`
+	Sender     string `json:"sender"`
+	From       string `json:"from"`
+	Subject    string `json:"subject"`
+	BodyMime   string `json:"body-mime"`
+}
+
 // plainMessage contains fields relevant to plain API-synthesized messages.
 // You're expected to use various setters to set most of these attributes,
 // although from, subject, and text are set when the message is created with
@@ -609,6 +617,20 @@ func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 	var response StoredMessage
 	err := getResponseFromJSON(r, &response)
 	return response, err
+}
+
+// GetStoredMessage retrieves information about a received e-mail message.
+// This provides visibility into, e.g., replies to a message sent to a mailing list.
+func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) {
+	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
+	r := simplehttp.NewHTTPRequest(url)
+	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
+	r.AddHeader("Accept", "message/rfc2822")
+
+	var response StoredMessageRaw
+	err := getResponseFromJSON(r, &response)
+	return response, err
+
 }
 
 // DeleteStoredMessage removes a previously stored message.


### PR DESCRIPTION
As documented in the Mailgun API, it is possible to read a stored message in raw MIME format, but the Go library doesn't have a function to do it. This PR adds it. 