### PR TITLE
Fix client access references.

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -2,8 +2,9 @@ package mailgun
 
 import (
 	"fmt"
-	"github.com/mbanzon/simplehttp"
 	"strconv"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 // A Credential structure describes a principle allowed to send or receive mail at the domain.
@@ -19,7 +20,7 @@ var ErrEmptyParam = fmt.Errorf("empty or illegal parameter")
 // GetCredentials returns the (possibly zero-length) list of credentials associated with your domain.
 func (mg *MailgunImpl) GetCredentials(limit, skip int) (int, []Credential, error) {
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, ""))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -44,7 +45,7 @@ func (mg *MailgunImpl) CreateCredential(login, password string) error {
 		return ErrEmptyParam
 	}
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, ""))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("login", login)
@@ -59,7 +60,7 @@ func (mg *MailgunImpl) ChangeCredentialPassword(id, password string) error {
 		return ErrEmptyParam
 	}
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, id))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("password", password)
@@ -73,7 +74,7 @@ func (mg *MailgunImpl) DeleteCredential(id string) error {
 		return ErrEmptyParam
 	}
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, id))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/events.go
+++ b/events.go
@@ -2,8 +2,9 @@ package mailgun
 
 import (
 	"fmt"
-	"github.com/mbanzon/simplehttp"
 	"time"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 // Events are open-ended, loosely-defined JSON documents.
@@ -106,7 +107,7 @@ func (ei *EventIterator) GetNext() error {
 // fetch completes the API fetch common to all three of these functions.
 func (ei *EventIterator) fetch(url string) error {
 	r := simplehttp.NewHTTPRequest(url)
-	r.SetClient(m.client)
+	r.SetClient(ei.mg.(*MailgunImpl).client)
 	r.SetBasicAuth(basicAuthUser, ei.mg.ApiKey())
 	var response map[string]interface{}
 	err := getResponseFromJSON(r, &response)

--- a/mailing_lists.go
+++ b/mailing_lists.go
@@ -3,8 +3,9 @@ package mailgun
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mbanzon/simplehttp"
 	"strconv"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 // A mailing list may have one of three membership modes.
@@ -64,7 +65,7 @@ type Member struct {
 // GetLists returns the specified set of mailing lists administered by your account.
 func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if limit != DefaultLimit {
@@ -122,7 +123,7 @@ func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
 // Attempts to send e-mail to the list will fail subsequent to this call.
 func (mg *MailgunImpl) DeleteList(addr string) error {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -132,7 +133,7 @@ func (mg *MailgunImpl) DeleteList(addr string) error {
 // representing a mailing list, so long as you have its e-mail address.
 func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
 	var envelope struct {
@@ -180,7 +181,7 @@ func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
 // Subscribed and Unsubscribed indicate you want only those eponymous subsets.
 func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, []Member, error) {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if limit != DefaultLimit {
@@ -208,7 +209,7 @@ func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, [
 // given only their subscription e-mail address.
 func (mg *MailgunImpl) GetMemberByAddress(s, l string) (Member, error) {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
 	if err != nil {
@@ -232,7 +233,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	p := simplehttp.NewFormDataPayload()
 	p.AddValue("upsert", yesNo(merge))
 	p.AddValue("address", prototype.Address)
@@ -249,7 +250,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 // Address, Name, Vars, and Subscribed fields may be changed.
 func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, error) {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	if prototype.Address != "" {
@@ -282,7 +283,7 @@ func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, erro
 // DeleteMember removes the member from the list.
 func (mg *MailgunImpl) DeleteMember(member, addr string) error {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + "/" + member)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -299,7 +300,7 @@ func (mg *MailgunImpl) DeleteMember(member, addr string) error {
 // Other fields are optional, but may be set according to your needs.
 func (mg *MailgunImpl) CreateMemberList(s *bool, addr string, newMembers []interface{}) error {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + ".json")
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	if s != nil {

--- a/messages.go
+++ b/messages.go
@@ -3,9 +3,10 @@ package mailgun
 import (
 	"encoding/json"
 	"errors"
-	"github.com/mbanzon/simplehttp"
 	"io"
 	"time"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 // MaxNumberOfRecipients represents the largest batch of recipients that Mailgun can support in a single API call.
@@ -605,7 +606,7 @@ func validateStringList(list []string, requireOne bool) bool {
 func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
 	r := simplehttp.NewHTTPRequest(url)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 
 	var response StoredMessage
@@ -619,7 +620,7 @@ func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 func (mg *MailgunImpl) DeleteStoredMessage(id string) error {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
 	r := simplehttp.NewHTTPRequest(url)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/routes.go
+++ b/routes.go
@@ -1,8 +1,9 @@
 package mailgun
 
 import (
-	"github.com/mbanzon/simplehttp"
 	"strconv"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 // A Route structure contains information on a configured or to-be-configured route.
@@ -35,7 +36,7 @@ type Route struct {
 // See the Mailgun documentation for more information.
 func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -61,7 +62,7 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 // See the Route structure definition for more details.
 func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("priority", strconv.Itoa(prototype.Priority))
@@ -83,7 +84,7 @@ func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 // See the Route structure definition and the Mailgun API documentation for more details.
 func (mg *MailgunImpl) DeleteRoute(id string) error {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -92,7 +93,7 @@ func (mg *MailgunImpl) DeleteRoute(id string) error {
 // GetRouteByID retrieves the complete route definition associated with the unique route ID.
 func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Message string `json:"message"`
@@ -107,7 +108,7 @@ func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 // All other fields remain as-is.
 func (mg *MailgunImpl) UpdateRoute(id string, route Route) (Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if route.Priority != 0 {

--- a/unsubscribes.go
+++ b/unsubscribes.go
@@ -1,8 +1,9 @@
 package mailgun
 
 import (
-	"github.com/mbanzon/simplehttp"
 	"strconv"
+
+	"github.com/mbanzon/simplehttp"
 )
 
 type Unsubscription struct {
@@ -16,7 +17,7 @@ type Unsubscription struct {
 // Zero is a valid list length.
 func (mg *MailgunImpl) GetUnsubscribes(limit, skip int) (int, []Unsubscription, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -36,7 +37,7 @@ func (mg *MailgunImpl) GetUnsubscribes(limit, skip int) (int, []Unsubscription, 
 // Zero is a valid list length.
 func (mg *MailgunImpl) GetUnsubscribesByAddress(a string) (int, []Unsubscription, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		TotalCount int              `json:"total_count"`
@@ -49,7 +50,7 @@ func (mg *MailgunImpl) GetUnsubscribesByAddress(a string) (int, []Unsubscription
 // Unsubscribe adds an e-mail address to the domain's unsubscription table.
 func (mg *MailgunImpl) Unsubscribe(a, t string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("address", a)
@@ -63,7 +64,7 @@ func (mg *MailgunImpl) Unsubscribe(a, t string) error {
 // with the given ID will be removed.
 func (mg *MailgunImpl) RemoveUnsubscribe(a string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/webhooks.go
+++ b/webhooks.go
@@ -8,7 +8,7 @@ import (
 // Note that a zero-length mapping is not an error.
 func (mg *MailgunImpl) GetWebhooks() (map[string]string, error) {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Webhooks map[string]interface{} `json:"webhooks"`
@@ -29,7 +29,7 @@ func (mg *MailgunImpl) GetWebhooks() (map[string]string, error) {
 // CreateWebhook installs a new webhook for your domain.
 func (mg *MailgunImpl) CreateWebhook(t, u string) error {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("id", t)
@@ -41,7 +41,7 @@ func (mg *MailgunImpl) CreateWebhook(t, u string) error {
 // DeleteWebhook removes the specified webhook from your domain's configuration.
 func (mg *MailgunImpl) DeleteWebhook(t string) error {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -50,7 +50,7 @@ func (mg *MailgunImpl) DeleteWebhook(t string) error {
 // GetWebhookByType retrieves the currently assigned webhook URL associated with the provided type of webhook.
 func (mg *MailgunImpl) GetWebhookByType(t string) (string, error) {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Webhook struct {
@@ -64,7 +64,7 @@ func (mg *MailgunImpl) GetWebhookByType(t string) (string, error) {
 // UpdateWebhook replaces one webhook setting for another.
 func (mg *MailgunImpl) UpdateWebhook(t, u string) error {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
-	r.SetClient(m.client)
+	r.SetClient(mg.client)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("url", u)


### PR DESCRIPTION
Fixes the issues mentioned in https://github.com/mailgun/mailgun-go/issues/24#issuecomment-68640262

Note, there is one hack in it: events.go, line 110 it uses an interface dereference to access the client.