### PR TITLE
Allow setting custom http.Client

### DIFF
--- a/bounces.go
+++ b/bounces.go
@@ -38,7 +38,7 @@ func (i Bounce) GetCreatedAt() (t time.Time, err error) {
 // and the slice of bounces specified, if successful.
 // Note that the length of the slice may be smaller than the total number of bounces.
 func (m *MailgunImpl) GetBounces(limit, skip int) (int, []Bounce, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, bouncesEndpoint))
 	if limit != -1 {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -59,7 +59,7 @@ func (m *MailgunImpl) GetBounces(limit, skip int) (int, []Bounce, error) {
 
 // GetSingleBounce retrieves a single bounce record, if any exist, for the given recipient address.
 func (m *MailgunImpl) GetSingleBounce(address string) (Bounce, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint) + "/" + address)
+	r := m.newHTTPRequest(generateApiUrl(m, bouncesEndpoint) + "/" + address)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var response singleBounceEnvelope
@@ -84,7 +84,7 @@ func (m *MailgunImpl) GetSingleBounce(address string) (Bounce, error) {
 // Note that both code and error exist as strings, even though
 // code will report as a number.
 func (m *MailgunImpl) AddBounce(address, code, error string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, bouncesEndpoint))
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -101,7 +101,7 @@ func (m *MailgunImpl) AddBounce(address, code, error string) error {
 
 // DeleteBounce removes all bounces associted with the provided e-mail address.
 func (m *MailgunImpl) DeleteBounce(address string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint) + "/" + address)
+	r := m.newHTTPRequest(generateApiUrl(m, bouncesEndpoint) + "/" + address)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/campaigns.go
+++ b/campaigns.go
@@ -28,7 +28,7 @@ type campaignsEnvelope struct {
 // Campaigns have been deprecated since development work on this SDK commenced.
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) GetCampaigns() (int, []Campaign, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, campaignsEndpoint))
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var envelope campaignsEnvelope
@@ -42,7 +42,7 @@ func (m *MailgunImpl) GetCampaigns() (int, []Campaign, error) {
 // Campaigns have been deprecated since development work on this SDK commenced.
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) CreateCampaign(name, id string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, campaignsEndpoint))
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -57,7 +57,7 @@ func (m *MailgunImpl) CreateCampaign(name, id string) error {
 // Campaigns have been deprecated since development work on this SDK commenced.
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) UpdateCampaign(oldId, name, newId string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint) + "/" + oldId)
+	r := m.newHTTPRequest(generateApiUrl(m, campaignsEndpoint) + "/" + oldId)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -72,7 +72,7 @@ func (m *MailgunImpl) UpdateCampaign(oldId, name, newId string) error {
 // Campaigns have been deprecated since development work on this SDK commenced.
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) DeleteCampaign(id string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint) + "/" + id)
+	r := m.newHTTPRequest(generateApiUrl(m, campaignsEndpoint) + "/" + id)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/credentials.go
+++ b/credentials.go
@@ -18,7 +18,7 @@ var ErrEmptyParam = fmt.Errorf("empty or illegal parameter")
 
 // GetCredentials returns the (possibly zero-length) list of credentials associated with your domain.
 func (mg *MailgunImpl) GetCredentials(limit, skip int) (int, []Credential, error) {
-	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, ""))
+	r := mg.newHTTPRequest(generateCredentialsUrl(mg, ""))
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -42,7 +42,7 @@ func (mg *MailgunImpl) CreateCredential(login, password string) error {
 	if (login == "") || (password == "") {
 		return ErrEmptyParam
 	}
-	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, ""))
+	r := mg.newHTTPRequest(generateCredentialsUrl(mg, ""))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("login", login)
@@ -56,7 +56,7 @@ func (mg *MailgunImpl) ChangeCredentialPassword(id, password string) error {
 	if (id == "") || (password == "") {
 		return ErrEmptyParam
 	}
-	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, id))
+	r := mg.newHTTPRequest(generateCredentialsUrl(mg, id))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("password", password)
@@ -69,7 +69,7 @@ func (mg *MailgunImpl) DeleteCredential(id string) error {
 	if id == "" {
 		return ErrEmptyParam
 	}
-	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, id))
+	r := mg.newHTTPRequest(generateCredentialsUrl(mg, id))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/domains.go
+++ b/domains.go
@@ -67,7 +67,7 @@ func (d Domain) GetCreatedAt() (t time.Time, err error) {
 // Note that zero items and a zero-length slice do not necessarily imply an error occurred.
 // Except for the error itself, all results are undefined in the event of an error.
 func (m *MailgunImpl) GetDomains(limit, skip int) (int, []Domain, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint))
+	r := m.newHTTPRequest(generatePublicApiUrl(domainsEndpoint))
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -86,7 +86,7 @@ func (m *MailgunImpl) GetDomains(limit, skip int) (int, []Domain, error) {
 
 // Retrieve detailed information about the named domain.
 func (m *MailgunImpl) GetSingleDomain(domain string) (Domain, []DNSRecord, []DNSRecord, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + domain)
+	r := m.newHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + domain)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	var envelope singleDomainEnvelope
 	err := getResponseFromJSON(r, &envelope)
@@ -100,7 +100,7 @@ func (m *MailgunImpl) GetSingleDomain(domain string) (Domain, []DNSRecord, []DNS
 // The wildcard parameter instructs Mailgun to treat all subdomains of this domain uniformly if true,
 // and as different domains if false.
 func (m *MailgunImpl) CreateDomain(name string, smtpPassword string, spamAction string, wildcard bool) error {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint))
+	r := m.newHTTPRequest(generatePublicApiUrl(domainsEndpoint))
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -114,7 +114,7 @@ func (m *MailgunImpl) CreateDomain(name string, smtpPassword string, spamAction 
 
 // DeleteDomain instructs Mailgun to dispose of the named domain name.
 func (m *MailgunImpl) DeleteDomain(name string) error {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + name)
+	r := m.newHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + name)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/email_validation.go
+++ b/email_validation.go
@@ -1,7 +1,6 @@
 package mailgun
 
 import (
-	"github.com/mbanzon/simplehttp"
 	"strings"
 )
 
@@ -41,7 +40,7 @@ type addressParseResult struct {
 // It may also be used to break an email address into its sub-components.  (See example.)
 // NOTE: Use of this function requires a proper public API key.  The private API key will not work.
 func (m *MailgunImpl) ValidateEmail(email string) (EmailVerification, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(addressValidateEndpoint))
+	r := m.newHTTPRequest(generatePublicApiUrl(addressValidateEndpoint))
 	r.AddParameter("address", email)
 	r.SetBasicAuth(basicAuthUser, m.PublicApiKey())
 
@@ -57,7 +56,7 @@ func (m *MailgunImpl) ValidateEmail(email string) (EmailVerification, error) {
 // ParseAddresses takes a list of addresses and sorts them into valid and invalid address categories.
 // NOTE: Use of this function requires a proper public API key.  The private API key will not work.
 func (m *MailgunImpl) ParseAddresses(addresses ...string) ([]string, []string, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(addressParseEndpoint))
+	r := m.newHTTPRequest(generatePublicApiUrl(addressParseEndpoint))
 	r.AddParameter("addresses", strings.Join(addresses, ","))
 	r.SetBasicAuth(basicAuthUser, m.PublicApiKey())
 

--- a/events.go
+++ b/events.go
@@ -3,6 +3,7 @@ package mailgun
 import (
 	"fmt"
 	"github.com/mbanzon/simplehttp"
+	"net/http"
 	"time"
 )
 
@@ -36,13 +37,14 @@ type EventIterator struct {
 	events           []Event
 	nextURL, prevURL string
 	mg               Mailgun
+	client           *http.Client
 }
 
 // NewEventIterator creates a new iterator for events.
 // Use GetFirstPage to retrieve the first batch of events.
 // Use Next and Previous thereafter as appropriate to iterate through sets of data.
 func (mg *MailgunImpl) NewEventIterator() *EventIterator {
-	return &EventIterator{mg: mg}
+	return &EventIterator{mg: mg, client: mg.client}
 }
 
 // Events returns the most recently retrieved batch of events.
@@ -106,6 +108,7 @@ func (ei *EventIterator) GetNext() error {
 // fetch completes the API fetch common to all three of these functions.
 func (ei *EventIterator) fetch(url string) error {
 	r := simplehttp.NewHTTPRequest(url)
+	r.SetClient(ei.client)
 	r.SetBasicAuth(basicAuthUser, ei.mg.ApiKey())
 	var response map[string]interface{}
 	err := getResponseFromJSON(r, &response)

--- a/mailing_lists.go
+++ b/mailing_lists.go
@@ -63,7 +63,7 @@ type Member struct {
 
 // GetLists returns the specified set of mailing lists administered by your account.
 func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint))
+	r := mg.newHTTPRequest(generatePublicApiUrl(listsEndpoint))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if limit != DefaultLimit {
@@ -93,7 +93,7 @@ func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, er
 // If unspecified, Description remains blank,
 // while AccessLevel defaults to Everyone.
 func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint))
+	r := mg.newHTTPRequest(generatePublicApiUrl(listsEndpoint))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if prototype.Address != "" {
@@ -120,7 +120,7 @@ func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
 // DeleteList removes all current members of the list, then removes the list itself.
 // Attempts to send e-mail to the list will fail subsequent to this call.
 func (mg *MailgunImpl) DeleteList(addr string) error {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r := mg.newHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -129,7 +129,7 @@ func (mg *MailgunImpl) DeleteList(addr string) error {
 // GetListByAddress allows your application to recover the complete List structure
 // representing a mailing list, so long as you have its e-mail address.
 func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r := mg.newHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
 	var envelope struct {
@@ -147,7 +147,7 @@ func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
 // e-mail sent to the old address will not succeed.
 // Make sure you account for the change accordingly.
 func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r := mg.newHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if prototype.Address != "" {
@@ -176,7 +176,7 @@ func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
 // All indicates that you want both Members and unsubscribed members alike, while
 // Subscribed and Unsubscribed indicate you want only those eponymous subsets.
 func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, []Member, error) {
-	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
+	r := mg.newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if limit != DefaultLimit {
@@ -203,7 +203,7 @@ func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, [
 // GetMemberByAddress returns a complete Member structure for a member of a mailing list,
 // given only their subscription e-mail address.
 func (mg *MailgunImpl) GetMemberByAddress(s, l string) (Member, error) {
-	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
+	r := mg.newHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
 	if err != nil {
@@ -225,7 +225,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 		return err
 	}
 
-	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
+	r := mg.newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	p.AddValue("upsert", yesNo(merge))
@@ -242,7 +242,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 // UpdateMember lets you change certain details about the indicated mailing list member.
 // Address, Name, Vars, and Subscribed fields may be changed.
 func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, error) {
-	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
+	r := mg.newHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	if prototype.Address != "" {
@@ -274,7 +274,7 @@ func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, erro
 
 // DeleteMember removes the member from the list.
 func (mg *MailgunImpl) DeleteMember(member, addr string) error {
-	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + "/" + member)
+	r := mg.newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + "/" + member)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -290,7 +290,7 @@ func (mg *MailgunImpl) DeleteMember(member, addr string) error {
 // Otherwise, each Member needs to have at least the Address field filled out.
 // Other fields are optional, but may be set according to your needs.
 func (mg *MailgunImpl) CreateMemberList(s *bool, addr string, newMembers []interface{}) error {
-	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + ".json")
+	r := mg.newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + ".json")
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	if s != nil {

--- a/messages.go
+++ b/messages.go
@@ -486,7 +486,7 @@ func (m *MailgunImpl) Send(message *Message) (mes string, id string, err error) 
 			}
 		}
 
-		r := simplehttp.NewHTTPRequest(generateApiUrl(m, message.specific.endpoint()))
+		r := m.newHTTPRequest(generateApiUrl(m, message.specific.endpoint()))
 		r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 		var response sendMessageResponse
@@ -612,7 +612,7 @@ func validateStringList(list []string, requireOne bool) bool {
 // This provides visibility into, e.g., replies to a message sent to a mailing list.
 func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
-	r := simplehttp.NewHTTPRequest(url)
+	r := mg.newHTTPRequest(url)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 
 	var response StoredMessage
@@ -625,7 +625,7 @@ func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 // thus delegates to the caller the required parsing.
 func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
-	r := simplehttp.NewHTTPRequest(url)
+	r := mg.newHTTPRequest(url)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	r.AddHeader("Accept", "message/rfc2822")
 
@@ -640,7 +640,7 @@ func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) 
 // Consult the current Mailgun API documentation for more details.
 func (mg *MailgunImpl) DeleteStoredMessage(id string) error {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
-	r := simplehttp.NewHTTPRequest(url)
+	r := mg.newHTTPRequest(url)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/routes.go
+++ b/routes.go
@@ -34,7 +34,7 @@ type Route struct {
 // messages sent to a specfic address on your domain.
 // See the Mailgun documentation for more information.
 func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint))
+	r := mg.newHTTPRequest(generatePublicApiUrl(routesEndpoint))
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -59,7 +59,7 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 // only a subset of the fields influence the operation.
 // See the Route structure definition for more details.
 func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint))
+	r := mg.newHTTPRequest(generatePublicApiUrl(routesEndpoint))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("priority", strconv.Itoa(prototype.Priority))
@@ -80,7 +80,7 @@ func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 // To avoid ambiguity, Mailgun identifies the route by unique ID.
 // See the Route structure definition and the Mailgun API documentation for more details.
 func (mg *MailgunImpl) DeleteRoute(id string) error {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r := mg.newHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -88,7 +88,7 @@ func (mg *MailgunImpl) DeleteRoute(id string) error {
 
 // GetRouteByID retrieves the complete route definition associated with the unique route ID.
 func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r := mg.newHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Message string `json:"message"`
@@ -102,7 +102,7 @@ func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 // Only those route fields which are non-zero or non-empty are updated.
 // All other fields remain as-is.
 func (mg *MailgunImpl) UpdateRoute(id string, route Route) (Route, error) {
-	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r := mg.newHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if route.Priority != 0 {

--- a/spam_complaints.go
+++ b/spam_complaints.go
@@ -28,7 +28,7 @@ type complaintsEnvelope struct {
 // Recipients of your messages can click on a link which sends feedback to Mailgun
 // indicating that the message they received is, to them, spam.
 func (m *MailgunImpl) GetComplaints(limit, skip int) (int, []Complaint, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, complaintsEndpoint))
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	if limit != -1 {
@@ -49,7 +49,7 @@ func (m *MailgunImpl) GetComplaints(limit, skip int) (int, []Complaint, error) {
 // GetSingleComplaint returns a single complaint record filed by a recipient at the email address provided.
 // If no complaint exists, the Complaint instance returned will be empty.
 func (m *MailgunImpl) GetSingleComplaint(address string) (Complaint, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint) + "/" + address)
+	r := m.newHTTPRequest(generateApiUrl(m, complaintsEndpoint) + "/" + address)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var c Complaint
@@ -60,7 +60,7 @@ func (m *MailgunImpl) GetSingleComplaint(address string) (Complaint, error) {
 // CreateComplaint registers the specified address as a recipient who has complained of receiving spam
 // from your domain.
 func (m *MailgunImpl) CreateComplaint(address string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, complaintsEndpoint))
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("address", address)
@@ -71,7 +71,7 @@ func (m *MailgunImpl) CreateComplaint(address string) error {
 // DeleteComplaint removes a previously registered e-mail address from the list of people who complained
 // of receiving spam from your domain.
 func (m *MailgunImpl) DeleteComplaint(address string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint) + "/" + address)
+	r := m.newHTTPRequest(generateApiUrl(m, complaintsEndpoint) + "/" + address)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/stats.go
+++ b/stats.go
@@ -1,7 +1,6 @@
 package mailgun
 
 import (
-	"github.com/mbanzon/simplehttp"
 	"strconv"
 	"time"
 )
@@ -23,7 +22,7 @@ type statsEnvelope struct {
 // Events start at the given start date, if one is provided.
 // If not, this function will consider all stated events dating to the creation of the sending domain.
 func (m *MailgunImpl) GetStats(limit int, skip int, startDate *time.Time, event ...string) (int, []Stat, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, statsEndpoint))
+	r := m.newHTTPRequest(generateApiUrl(m, statsEndpoint))
 
 	if limit != -1 {
 		r.AddParameter("limit", strconv.Itoa(limit))
@@ -52,7 +51,7 @@ func (m *MailgunImpl) GetStats(limit int, skip int, startDate *time.Time, event 
 
 // DeleteTag removes all counters for a particular tag, including the tag itself.
 func (m *MailgunImpl) DeleteTag(tag string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(m, deleteTagEndpoint) + "/" + tag)
+	r := m.newHTTPRequest(generateApiUrl(m, deleteTagEndpoint) + "/" + tag)
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/unsubscribes.go
+++ b/unsubscribes.go
@@ -15,7 +15,7 @@ type Unsubscription struct {
 // GetUnsubscribes retrieves a list of unsubscriptions issued by recipients of mail from your domain.
 // Zero is a valid list length.
 func (mg *MailgunImpl) GetUnsubscribes(limit, skip int) (int, []Unsubscription, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
+	r := mg.newHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -34,7 +34,7 @@ func (mg *MailgunImpl) GetUnsubscribes(limit, skip int) (int, []Unsubscription, 
 // GetUnsubscribesByAddress retrieves a list of unsubscriptions by recipient address.
 // Zero is a valid list length.
 func (mg *MailgunImpl) GetUnsubscribesByAddress(a string) (int, []Unsubscription, error) {
-	r := simplehttp.NewHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
+	r := mg.newHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		TotalCount int              `json:"total_count"`
@@ -46,7 +46,7 @@ func (mg *MailgunImpl) GetUnsubscribesByAddress(a string) (int, []Unsubscription
 
 // Unsubscribe adds an e-mail address to the domain's unsubscription table.
 func (mg *MailgunImpl) Unsubscribe(a, t string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
+	r := mg.newHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("address", a)
@@ -59,7 +59,7 @@ func (mg *MailgunImpl) Unsubscribe(a, t string) error {
 // If passing in an ID (discoverable from, e.g., GetUnsubscribes()), the e-mail address associated
 // with the given ID will be removed.
 func (mg *MailgunImpl) RemoveUnsubscribe(a string) error {
-	r := simplehttp.NewHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
+	r := mg.newHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/webhooks.go
+++ b/webhooks.go
@@ -7,7 +7,7 @@ import (
 // GetWebhooks returns the complete set of webhooks configured for your domain.
 // Note that a zero-length mapping is not an error.
 func (mg *MailgunImpl) GetWebhooks() (map[string]string, error) {
-	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
+	r := mg.newHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Webhooks map[string]interface{} `json:"webhooks"`
@@ -27,7 +27,7 @@ func (mg *MailgunImpl) GetWebhooks() (map[string]string, error) {
 
 // CreateWebhook installs a new webhook for your domain.
 func (mg *MailgunImpl) CreateWebhook(t, u string) error {
-	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
+	r := mg.newHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("id", t)
@@ -38,7 +38,7 @@ func (mg *MailgunImpl) CreateWebhook(t, u string) error {
 
 // DeleteWebhook removes the specified webhook from your domain's configuration.
 func (mg *MailgunImpl) DeleteWebhook(t string) error {
-	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
+	r := mg.newHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -46,7 +46,7 @@ func (mg *MailgunImpl) DeleteWebhook(t string) error {
 
 // GetWebhookByType retrieves the currently assigned webhook URL associated with the provided type of webhook.
 func (mg *MailgunImpl) GetWebhookByType(t string) (string, error) {
-	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
+	r := mg.newHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Webhook struct {
@@ -59,7 +59,7 @@ func (mg *MailgunImpl) GetWebhookByType(t string) (string, error) {
 
 // UpdateWebhook replaces one webhook setting for another.
 func (mg *MailgunImpl) UpdateWebhook(t, u string) error {
-	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
+	r := mg.newHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("url", u)


### PR DESCRIPTION
Swapping the http.Client is necessary to run apps in AppEngine.

It's also good practice in order to let people set custom clients.

e.g.: Setting a custom transport to log http requests/replies for
debugging using github.com/ernesto-jimenez/httplogger