### PR TITLE
Fix compatibility with Mailgun API protocol bug.

### DIFF
--- a/bounces.go
+++ b/bounces.go
@@ -12,10 +12,10 @@ import (
 // while Error provides a human readable reason why.
 // CreatedAt provides the time at which Mailgun detected the bounce.
 type Bounce struct {
-	CreatedAt string `json:"created_at"`
-	Code      string `json:"code"`
-	Address   string `json:"address"`
-	Error     string `json:"error"`
+	CreatedAt string      `json:"created_at"`
+	code      interface{} `json:"code"`
+	Address   string      `json:"address"`
+	Error     string      `json:"error"`
 }
 
 type bounceEnvelope struct {
@@ -31,6 +31,20 @@ type singleBounceEnvelope struct {
 // Time structure.
 func (i Bounce) GetCreatedAt() (t time.Time, err error) {
 	return parseMailgunTime(i.CreatedAt)
+}
+
+// GetCode will return the bounce code for the message, regardless if it was
+// returned as a string or as an integer.  This method overcomes a protocol
+// bug in the Mailgun API.
+func (b Bounce) GetCode() (int, error) {
+	switch c := b.code.(type) {
+	case int:
+		return c, nil
+	case string:
+		return strconv.Atoi(c)
+	default:
+		return -1, strconv.ErrSyntax
+	}
 }
 
 // GetBounces returns a complete set of bounces logged against the sender's domain, if any.

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -1,6 +1,7 @@
 package mailgun
 
 import (
+	"strconv"
 	"testing"
 )
 
@@ -21,5 +22,47 @@ func TestMailgun(t *testing.T) {
 
 	if publicApiKey != m.PublicApiKey() {
 		t.Fatal("PublicApiKey not equal!")
+	}
+}
+
+func TestBounceGetCode(t *testing.T) {
+	b1 := &Bounce{
+		CreatedAt: "blah",
+		code:      123,
+		Address:   "blort",
+		Error:     "bletch",
+	}
+	c, err := b1.GetCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c != 123 {
+		t.Fatal("Expected 123; got ", c)
+	}
+
+	b2 := &Bounce{
+		CreatedAt: "blah",
+		code:      "456",
+		Address:   "blort",
+		Error:     "Bletch",
+	}
+	c, err = b2.GetCode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c != 456 {
+		t.Fatal("Expected 456; got ", c)
+	}
+
+	b3 := &Bounce{
+		CreatedAt: "blah",
+		code:      "456H",
+		Address:   "blort",
+		Error:     "Bletch",
+	}
+	c, err = b3.GetCode()
+	e, ok := err.(*strconv.NumError)
+	if !ok && e != nil {
+		t.Fatal("Expected a syntax error in numeric conversion: got ", err)
 	}
 }


### PR DESCRIPTION
Sometimes, bounce API returns status codes as strings, and other times
as integers.  This violates mailgun-go's interface conventions,
preventing us from using reflection to figure out how to automatically
decode the JSON response.

This introduces a BREAKING CHANGE to the Mailgun-go API.  However, it's
required to be enable compatbility with the existing API.

Fixes #20