### PR TITLE
Make http client configurable to support GAE

### DIFF
--- a/bounces.go
+++ b/bounces.go
@@ -60,6 +60,7 @@ func (m *MailgunImpl) GetBounces(limit, skip int) (int, []Bounce, error) {
 		r.AddParameter("skip", strconv.Itoa(skip))
 	}
 
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var response bounceEnvelope
@@ -74,6 +75,7 @@ func (m *MailgunImpl) GetBounces(limit, skip int) (int, []Bounce, error) {
 // GetSingleBounce retrieves a single bounce record, if any exist, for the given recipient address.
 func (m *MailgunImpl) GetSingleBounce(address string) (Bounce, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint) + "/" + address)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var response singleBounceEnvelope
@@ -99,6 +101,7 @@ func (m *MailgunImpl) GetSingleBounce(address string) (Bounce, error) {
 // code will report as a number.
 func (m *MailgunImpl) AddBounce(address, code, error string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint))
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -116,6 +119,7 @@ func (m *MailgunImpl) AddBounce(address, code, error string) error {
 // DeleteBounce removes all bounces associted with the provided e-mail address.
 func (m *MailgunImpl) DeleteBounce(address string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, bouncesEndpoint) + "/" + address)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/campaigns.go
+++ b/campaigns.go
@@ -29,6 +29,7 @@ type campaignsEnvelope struct {
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) GetCampaigns() (int, []Campaign, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint))
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var envelope campaignsEnvelope
@@ -43,6 +44,7 @@ func (m *MailgunImpl) GetCampaigns() (int, []Campaign, error) {
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) CreateCampaign(name, id string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint))
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -58,6 +60,7 @@ func (m *MailgunImpl) CreateCampaign(name, id string) error {
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) UpdateCampaign(oldId, name, newId string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint) + "/" + oldId)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -73,6 +76,7 @@ func (m *MailgunImpl) UpdateCampaign(oldId, name, newId string) error {
 // Please refer to http://documentation.mailgun.com/api_reference .
 func (m *MailgunImpl) DeleteCampaign(id string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, campaignsEndpoint) + "/" + id)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/credentials.go
+++ b/credentials.go
@@ -19,6 +19,7 @@ var ErrEmptyParam = fmt.Errorf("empty or illegal parameter")
 // GetCredentials returns the (possibly zero-length) list of credentials associated with your domain.
 func (mg *MailgunImpl) GetCredentials(limit, skip int) (int, []Credential, error) {
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, ""))
+	r.SetClient(mg.Client())
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -43,6 +44,7 @@ func (mg *MailgunImpl) CreateCredential(login, password string) error {
 		return ErrEmptyParam
 	}
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, ""))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("login", login)
@@ -57,6 +59,7 @@ func (mg *MailgunImpl) ChangeCredentialPassword(id, password string) error {
 		return ErrEmptyParam
 	}
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, id))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("password", password)
@@ -70,6 +73,7 @@ func (mg *MailgunImpl) DeleteCredential(id string) error {
 		return ErrEmptyParam
 	}
 	r := simplehttp.NewHTTPRequest(generateCredentialsUrl(mg, id))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/domains.go
+++ b/domains.go
@@ -68,6 +68,7 @@ func (d Domain) GetCreatedAt() (t time.Time, err error) {
 // Except for the error itself, all results are undefined in the event of an error.
 func (m *MailgunImpl) GetDomains(limit, skip int) (int, []Domain, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint))
+	r.SetClient(m.Client())
 	if limit != DefaultLimit {
 		r.AddParameter("limit", strconv.Itoa(limit))
 	}
@@ -87,6 +88,7 @@ func (m *MailgunImpl) GetDomains(limit, skip int) (int, []Domain, error) {
 // Retrieve detailed information about the named domain.
 func (m *MailgunImpl) GetSingleDomain(domain string) (Domain, []DNSRecord, []DNSRecord, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + domain)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	var envelope singleDomainEnvelope
 	err := getResponseFromJSON(r, &envelope)
@@ -101,6 +103,7 @@ func (m *MailgunImpl) GetSingleDomain(domain string) (Domain, []DNSRecord, []DNS
 // and as different domains if false.
 func (m *MailgunImpl) CreateDomain(name string, smtpPassword string, spamAction string, wildcard bool) error {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint))
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	payload := simplehttp.NewUrlEncodedPayload()
@@ -115,6 +118,7 @@ func (m *MailgunImpl) CreateDomain(name string, smtpPassword string, spamAction 
 // DeleteDomain instructs Mailgun to dispose of the named domain name.
 func (m *MailgunImpl) DeleteDomain(name string) error {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + name)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/email_validation.go
+++ b/email_validation.go
@@ -42,6 +42,7 @@ type addressParseResult struct {
 // NOTE: Use of this function requires a proper public API key.  The private API key will not work.
 func (m *MailgunImpl) ValidateEmail(email string) (EmailVerification, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(addressValidateEndpoint))
+	r.SetClient(m.Client())
 	r.AddParameter("address", email)
 	r.SetBasicAuth(basicAuthUser, m.PublicApiKey())
 
@@ -58,6 +59,7 @@ func (m *MailgunImpl) ValidateEmail(email string) (EmailVerification, error) {
 // NOTE: Use of this function requires a proper public API key.  The private API key will not work.
 func (m *MailgunImpl) ParseAddresses(addresses ...string) ([]string, []string, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(addressParseEndpoint))
+	r.SetClient(m.Client())
 	r.AddParameter("addresses", strings.Join(addresses, ","))
 	r.SetBasicAuth(basicAuthUser, m.PublicApiKey())
 

--- a/events.go
+++ b/events.go
@@ -106,6 +106,7 @@ func (ei *EventIterator) GetNext() error {
 // fetch completes the API fetch common to all three of these functions.
 func (ei *EventIterator) fetch(url string) error {
 	r := simplehttp.NewHTTPRequest(url)
+	r.SetClient(ei.mg.Client())
 	r.SetBasicAuth(basicAuthUser, ei.mg.ApiKey())
 	var response map[string]interface{}
 	err := getResponseFromJSON(r, &response)

--- a/mailgun.go
+++ b/mailgun.go
@@ -96,6 +96,7 @@ import (
 	"fmt"
 	"github.com/mbanzon/simplehttp"
 	"io"
+	"net/http"
 	"time"
 )
 
@@ -131,6 +132,8 @@ type Mailgun interface {
 	Domain() string
 	ApiKey() string
 	PublicApiKey() string
+	Client() *http.Client
+	SetClient(client *http.Client)
 	Send(m *Message) (string, string, error)
 	ValidateEmail(email string) (EmailVerification, error)
 	ParseAddresses(addresses ...string) ([]string, []string, error)
@@ -195,11 +198,17 @@ type MailgunImpl struct {
 	domain       string
 	apiKey       string
 	publicApiKey string
+	client       *http.Client
 }
 
 // NewMailGun creates a new client instance.
 func NewMailgun(domain, apiKey, publicApiKey string) Mailgun {
-	m := MailgunImpl{domain: domain, apiKey: apiKey, publicApiKey: publicApiKey}
+	m := MailgunImpl{
+		domain:       domain,
+		apiKey:       apiKey,
+		publicApiKey: publicApiKey,
+		client:       http.DefaultClient,
+	}
 	return &m
 }
 
@@ -216,6 +225,16 @@ func (m *MailgunImpl) ApiKey() string {
 // PublicApiKey returns the public API key configured for this client.
 func (m *MailgunImpl) PublicApiKey() string {
 	return m.publicApiKey
+}
+
+// Client returns the HTTP client configured for this client.
+func (m *MailgunImpl) Client() *http.Client {
+	return m.client
+}
+
+// SetClient updates the HTTP client for this client.
+func (m *MailgunImpl) SetClient(c *http.Client) {
+	m.client = c
 }
 
 // generateApiUrl renders a URL for an API endpoint using the domain and endpoint name.

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -1,6 +1,7 @@
 package mailgun
 
 import (
+	"net/http"
 	"strconv"
 	"testing"
 )
@@ -22,6 +23,15 @@ func TestMailgun(t *testing.T) {
 
 	if publicApiKey != m.PublicApiKey() {
 		t.Fatal("PublicApiKey not equal!")
+	}
+
+	if http.DefaultClient != m.Client() {
+		t.Fatal("HTTP client not default!")
+	}
+	client := new(http.Client)
+	m.SetClient(client)
+	if client != m.Client() {
+		t.Fatal("HTTP client not equal!")
 	}
 }
 

--- a/mailing_lists.go
+++ b/mailing_lists.go
@@ -64,6 +64,7 @@ type Member struct {
 // GetLists returns the specified set of mailing lists administered by your account.
 func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if limit != DefaultLimit {
@@ -94,6 +95,7 @@ func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, er
 // while AccessLevel defaults to Everyone.
 func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if prototype.Address != "" {
@@ -121,6 +123,7 @@ func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
 // Attempts to send e-mail to the list will fail subsequent to this call.
 func (mg *MailgunImpl) DeleteList(addr string) error {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -130,6 +133,7 @@ func (mg *MailgunImpl) DeleteList(addr string) error {
 // representing a mailing list, so long as you have its e-mail address.
 func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
 	var envelope struct {
@@ -148,6 +152,7 @@ func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
 // Make sure you account for the change accordingly.
 func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if prototype.Address != "" {
@@ -177,6 +182,7 @@ func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
 // Subscribed and Unsubscribed indicate you want only those eponymous subsets.
 func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, []Member, error) {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if limit != DefaultLimit {
@@ -204,6 +210,7 @@ func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, [
 // given only their subscription e-mail address.
 func (mg *MailgunImpl) GetMemberByAddress(s, l string) (Member, error) {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
 	if err != nil {
@@ -226,6 +233,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 	}
 
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	p.AddValue("upsert", yesNo(merge))
@@ -243,6 +251,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 // Address, Name, Vars, and Subscribed fields may be changed.
 func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, error) {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	if prototype.Address != "" {
@@ -275,6 +284,7 @@ func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, erro
 // DeleteMember removes the member from the list.
 func (mg *MailgunImpl) DeleteMember(member, addr string) error {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + "/" + member)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -291,6 +301,7 @@ func (mg *MailgunImpl) DeleteMember(member, addr string) error {
 // Other fields are optional, but may be set according to your needs.
 func (mg *MailgunImpl) CreateMemberList(s *bool, addr string, newMembers []interface{}) error {
 	r := simplehttp.NewHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + ".json")
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewFormDataPayload()
 	if s != nil {

--- a/messages.go
+++ b/messages.go
@@ -487,6 +487,7 @@ func (m *MailgunImpl) Send(message *Message) (mes string, id string, err error) 
 		}
 
 		r := simplehttp.NewHTTPRequest(generateApiUrl(m, message.specific.endpoint()))
+		r.SetClient(m.Client())
 		r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 		var response sendMessageResponse
@@ -613,6 +614,7 @@ func validateStringList(list []string, requireOne bool) bool {
 func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
 	r := simplehttp.NewHTTPRequest(url)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 
 	var response StoredMessage
@@ -626,6 +628,7 @@ func (mg *MailgunImpl) GetStoredMessage(id string) (StoredMessage, error) {
 func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
 	r := simplehttp.NewHTTPRequest(url)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	r.AddHeader("Accept", "message/rfc2822")
 
@@ -641,6 +644,7 @@ func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) 
 func (mg *MailgunImpl) DeleteStoredMessage(id string) error {
 	url := generateStoredMessageUrl(mg, messagesEndpoint, id)
 	r := simplehttp.NewHTTPRequest(url)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/routes.go
+++ b/routes.go
@@ -41,6 +41,7 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 	if skip != DefaultSkip {
 		r.AddParameter("skip", strconv.Itoa(skip))
 	}
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 
 	var envelope struct {
@@ -60,6 +61,7 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 // See the Route structure definition for more details.
 func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("priority", strconv.Itoa(prototype.Priority))
@@ -81,6 +83,7 @@ func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 // See the Route structure definition and the Mailgun API documentation for more details.
 func (mg *MailgunImpl) DeleteRoute(id string) error {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -89,6 +92,7 @@ func (mg *MailgunImpl) DeleteRoute(id string) error {
 // GetRouteByID retrieves the complete route definition associated with the unique route ID.
 func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Message string `json:"message"`
@@ -103,6 +107,7 @@ func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 // All other fields remain as-is.
 func (mg *MailgunImpl) UpdateRoute(id string, route Route) (Route, error) {
 	r := simplehttp.NewHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	if route.Priority != 0 {

--- a/spam_complaints.go
+++ b/spam_complaints.go
@@ -29,6 +29,7 @@ type complaintsEnvelope struct {
 // indicating that the message they received is, to them, spam.
 func (m *MailgunImpl) GetComplaints(limit, skip int) (int, []Complaint, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint))
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	if limit != -1 {
@@ -50,6 +51,7 @@ func (m *MailgunImpl) GetComplaints(limit, skip int) (int, []Complaint, error) {
 // If no complaint exists, the Complaint instance returned will be empty.
 func (m *MailgunImpl) GetSingleComplaint(address string) (Complaint, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint) + "/" + address)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var c Complaint
@@ -61,6 +63,7 @@ func (m *MailgunImpl) GetSingleComplaint(address string) (Complaint, error) {
 // from your domain.
 func (m *MailgunImpl) CreateComplaint(address string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint))
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("address", address)
@@ -72,6 +75,7 @@ func (m *MailgunImpl) CreateComplaint(address string) error {
 // of receiving spam from your domain.
 func (m *MailgunImpl) DeleteComplaint(address string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, complaintsEndpoint) + "/" + address)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/stats.go
+++ b/stats.go
@@ -39,6 +39,7 @@ func (m *MailgunImpl) GetStats(limit int, skip int, startDate *time.Time, event 
 	for _, e := range event {
 		r.AddParameter("event", e)
 	}
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 
 	var res statsEnvelope
@@ -53,6 +54,7 @@ func (m *MailgunImpl) GetStats(limit int, skip int, startDate *time.Time, event 
 // DeleteTag removes all counters for a particular tag, including the tag itself.
 func (m *MailgunImpl) DeleteTag(tag string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(m, deleteTagEndpoint) + "/" + tag)
+	r.SetClient(m.Client())
 	r.SetBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/unsubscribes.go
+++ b/unsubscribes.go
@@ -22,6 +22,7 @@ func (mg *MailgunImpl) GetUnsubscribes(limit, skip int) (int, []Unsubscription, 
 	if skip != DefaultSkip {
 		r.AddParameter("skip", strconv.Itoa(skip))
 	}
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		TotalCount int              `json:"total_count"`
@@ -35,6 +36,7 @@ func (mg *MailgunImpl) GetUnsubscribes(limit, skip int) (int, []Unsubscription, 
 // Zero is a valid list length.
 func (mg *MailgunImpl) GetUnsubscribesByAddress(a string) (int, []Unsubscription, error) {
 	r := simplehttp.NewHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		TotalCount int              `json:"total_count"`
@@ -47,6 +49,7 @@ func (mg *MailgunImpl) GetUnsubscribesByAddress(a string) (int, []Unsubscription
 // Unsubscribe adds an e-mail address to the domain's unsubscription table.
 func (mg *MailgunImpl) Unsubscribe(a, t string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrl(mg, unsubscribesEndpoint))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("address", a)
@@ -60,6 +63,7 @@ func (mg *MailgunImpl) Unsubscribe(a, t string) error {
 // with the given ID will be removed.
 func (mg *MailgunImpl) RemoveUnsubscribe(a string) error {
 	r := simplehttp.NewHTTPRequest(generateApiUrlWithTarget(mg, unsubscribesEndpoint, a))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err

--- a/webhooks.go
+++ b/webhooks.go
@@ -8,6 +8,7 @@ import (
 // Note that a zero-length mapping is not an error.
 func (mg *MailgunImpl) GetWebhooks() (map[string]string, error) {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Webhooks map[string]interface{} `json:"webhooks"`
@@ -28,6 +29,7 @@ func (mg *MailgunImpl) GetWebhooks() (map[string]string, error) {
 // CreateWebhook installs a new webhook for your domain.
 func (mg *MailgunImpl) CreateWebhook(t, u string) error {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint))
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("id", t)
@@ -39,6 +41,7 @@ func (mg *MailgunImpl) CreateWebhook(t, u string) error {
 // DeleteWebhook removes the specified webhook from your domain's configuration.
 func (mg *MailgunImpl) DeleteWebhook(t string) error {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
 	return err
@@ -47,6 +50,7 @@ func (mg *MailgunImpl) DeleteWebhook(t string) error {
 // GetWebhookByType retrieves the currently assigned webhook URL associated with the provided type of webhook.
 func (mg *MailgunImpl) GetWebhookByType(t string) (string, error) {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
 		Webhook struct {
@@ -60,6 +64,7 @@ func (mg *MailgunImpl) GetWebhookByType(t string) (string, error) {
 // UpdateWebhook replaces one webhook setting for another.
 func (mg *MailgunImpl) UpdateWebhook(t, u string) error {
 	r := simplehttp.NewHTTPRequest(generateDomainApiUrl(mg, webhooksEndpoint) + "/" + t)
+	r.SetClient(mg.Client())
 	r.SetBasicAuth(basicAuthUser, mg.ApiKey())
 	p := simplehttp.NewUrlEncodedPayload()
 	p.AddValue("url", u)


### PR DESCRIPTION
Applications in GAE are prevented from making HTTP requests using `http.DefaultClient` and must instead use Google's [urlfetch client](https://cloud.google.com/appengine/docs/go/urlfetch/).