### PR TITLE
content-id-map deserialized to a map of structs.

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -54,19 +54,24 @@ type ReaderAttachment struct {
 // because that's how it's sent over the wire, and it's how encoding/json expects this field
 // to be.
 type StoredMessage struct {
-	Recipients        string                 `json:"recipients"`
-	Sender            string                 `json:"sender"`
-	From              string                 `json:"from"`
-	Subject           string                 `json:"subject"`
-	BodyPlain         string                 `json:"body-plain"`
-	StrippedText      string                 `json:"stripped-text"`
-	StrippedSignature string                 `json:"stripped-signature"`
-	BodyHtml          string                 `json:"body-html"`
-	StrippedHtml      string                 `json:"stripped-html"`
-	Attachments       []StoredAttachment     `json:"attachments"`
-	MessageUrl        string                 `json:"message-url"`
-	ContentIDMap      map[string]interface{} `json:"content-id-map"`
-	MessageHeaders    [][]string             `json:"message-headers"`
+	Recipients        string             `json:"recipients"`
+	Sender            string             `json:"sender"`
+	From              string             `json:"from"`
+	Subject           string             `json:"subject"`
+	BodyPlain         string             `json:"body-plain"`
+	StrippedText      string             `json:"stripped-text"`
+	StrippedSignature string             `json:"stripped-signature"`
+	BodyHtml          string             `json:"body-html"`
+	StrippedHtml      string             `json:"stripped-html"`
+	Attachments       []StoredAttachment `json:"attachments"`
+	MessageUrl        string             `json:"message-url"`
+	ContentIDMap      map[string]struct {
+		Url         string `json:"url"`
+		ContentType string `json:"content-type"`
+		Name        string `json:"name"`
+		Size        int64  `json:"size"`
+	} `json:"content-id-map"`
+	MessageHeaders [][]string `json:"message-headers"`
 }
 
 // StoredAttachment structures contain information on an attachment associated with a stored message.


### PR DESCRIPTION
The format of the `content-id-map` JSON field of a stored message is known, so it's possible  to decode it to a defined type, instead of `map[string]interface{}`.