### PR TITLE
Added mailgun cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,20 +6,46 @@ Mailgun with Go
 
 Go library for interacting with the [Mailgun](https://mailgun.com/) [API](https://documentation.mailgun.com/api_reference.html).
 
-Download the library
+# Sending mail via the mailgun CLI
+Export your API keys and domain
+```bash
+$ export MG_API_KEY=your-api-key
+$ export MG_DOMAIN=your-domain
+$ export MG_PUBLIC_API_KEY=your-public-key
+```
+Send an email
+```bash
+$ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com
+```
 
+# Sending mail via the golang library
+```go
+package main
+
+import "gopkg.in/mailgun/mailgun-go.v1"
+
+mg := mailgun.NewMailgun(yourdomain, ApiKey, publicApiKey)
+message := mailgun.NewMessage(
+    "sender@example.com",
+    "Fancy subject!",
+    "Hello from Mailgun Go!",
+    "recipient@example.com")
+resp, id, err := mg.Send(message)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("ID: %s Resp: %s\n", id, resp)
+```
+
+# Installation
+Install the go library
 ```
 go get gopkg.in/mailgun/mailgun-go.v1
 ```
 
-# Sending mail
-
-You just need your domain, public and private API key from the Mailgun admin interface to get started sending using the
-library:
-
-```Go
-mg := mailgun.NewMailgun(domain, apiKey, publicApiKey)
-message := mailgun.NewMessage("sender@example.com", "Fancy subject!", "Hello from Mailgun Go!", "recipient@example.com")
+Install the mailgun CLI
+```
+go install github.com/mailgun/mailgun-go/cmd/mailgun/./...
 ```
 
 # Testing

--- a/cmd/mailgun/main.go
+++ b/cmd/mailgun/main.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/drhodes/golorem"
+	"github.com/mailgun/log"
+	"github.com/mailgun/mailgun-go"
+	"github.com/thrawn01/args"
+)
+
+func checkErr(msg string, err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s - %s\n", msg, err)
+		os.Exit(1)
+	}
+}
+
+func main() {
+	log.InitWithConfig(log.Config{Name: "console"})
+	desc := args.Dedent(`CLI for mailgun api
+
+	Examples:
+	   Set your credentials in the environment
+	   export MG_DOMAIN=your-domain-name
+	   export MG_API_KEY=your-api-key
+	   export MG_PUBLIC_API_KEY=your-public-api-key
+
+	   Post a simple event message from stdin
+	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com
+
+	 Help:
+	   For detailed help on send
+	   $ mailgun send -h`)
+
+	parser := args.NewParser(args.EnvPrefix("MG_"), args.Desc(desc, args.IsFormated))
+	parser.AddOption("--verbose").Alias("-v").IsTrue().Help("be verbose")
+	parser.AddOption("--url").Alias("-u").Env("URL").Default(mailgun.BaseURL).Help("url to the mailgun api")
+	parser.AddOption("--api-key").Alias("-a").Env("API_KEY").Help("mailgun api key")
+	parser.AddOption("--public-api-key").Alias("-p").Env("PUBLIC_API_KEY").Help("mailgun public api key")
+	parser.AddOption("--domain").Alias("-d").Env("DOMAIN").Help("mailgun api key")
+
+	// Commands
+	parser.AddCommand("send", Send)
+
+	// Parser and set global options
+	opts := parser.ParseArgsSimple(nil)
+	mailgun.BaseURL = opts.String("url")
+	if opts.Bool("verbose") {
+		mailgun.Debug = true
+	}
+
+	// Initialize our mailgun object
+	mg := mailgun.NewMailgun(
+		opts.String("domain"),
+		opts.String("api-key"),
+		opts.String("public-api-key"))
+
+	// Run the command chosen by our user
+	retCode, err := parser.RunCommand(mg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	os.Exit(retCode)
+}
+
+func Send(parser *args.ArgParser, data interface{}) int {
+	mg := data.(mailgun.Mailgun)
+	var content []byte
+	var err error
+	var count int
+
+	log.InitWithConfig(log.Config{Name: "console"})
+	desc := args.Dedent(`Send emails via the mailgun HTTP API
+
+	Examples:
+	   Post a simple email from stdin
+	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com
+
+	   Post a simple email to a specific domain
+	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com -d my-domain.com
+
+	   Post a test lorem ipsum email (random content, and subject)
+	   $ mailgun send --lorem address@example.com
+
+	   Post a 10 random test lorem ipsum emails
+	   $ mailgun send --lorem address@example.com --count 10`)
+
+	parser.SetDesc(desc)
+	parser.AddOption("--subject").Alias("-s").Help("subject of the message")
+	parser.AddOption("--tags").IsStringSlice().Alias("-t").Help("comma separated list of tags")
+	parser.AddOption("--from").Alias("-f").Env("FROM").Help("from address, defaults to <user>@<hostname>")
+	parser.AddOption("--lorem").Alias("-l").IsTrue().Help("generate a randome subject and message content")
+	parser.AddOption("--count").StoreInt(&count).Default("1").Alias("-c").Help("send the email x number of counts")
+	parser.AddArgument("addresses").IsStringSlice().Required().Help("a list of email addresses")
+
+	opts := parser.ParseArgsSimple(nil)
+
+	// Required for send
+	if err := opts.Required([]string{"domain", "api-key"}); err != nil {
+		fmt.Fprintf(os.Stderr, "Missing Required option '%s'", err)
+		return 1
+	}
+
+	// Default to user@hostname if no from address provided
+	if !opts.IsSet("from") {
+		host, err := os.Hostname()
+		checkErr("Hostname Error", err)
+		opts.Set("from", fmt.Sprintf("%s@%s", os.Getenv("USER"), host))
+	}
+
+	// Read the content from stdin
+	if !opts.Bool("lorem") {
+		// If stdin is not open and character device
+		if !args.IsCharDevice(os.Stdin) {
+			parser.PrintHelp()
+			return 1
+		}
+		content, err = ioutil.ReadAll(os.Stdin)
+		checkErr("Error reading stdin", err)
+	}
+
+	subject := opts.String("subject")
+	for i := 0; i < count; i++ {
+		if opts.Bool("lorem") {
+			subject = lorem.Sentence(3, 5)
+			content = []byte(lorem.Paragraph(10, 50))
+		}
+		resp, id, err := mg.Send(mg.NewMessage(
+			opts.String("from"),
+			subject,
+			string(content),
+			opts.StringSlice("addresses")...))
+		checkErr("Message Error", err)
+		fmt.Printf("Id: %s Resp: %s\n", id, resp)
+	}
+	return 0
+}

--- a/mailgun.go
+++ b/mailgun.go
@@ -102,7 +102,7 @@ import (
 var Debug = false
 
 const (
-	apiBase                 = "https://api.mailgun.net/v3"
+	ApiBase                 = "https://api.mailgun.net/v3"
 	messagesEndpoint        = "messages"
 	mimeMessagesEndpoint    = "messages.mime"
 	addressValidateEndpoint = "address/validate"
@@ -209,7 +209,7 @@ type MailgunImpl struct {
 // NewMailGun creates a new client instance.
 func NewMailgun(domain, apiKey, publicApiKey string) Mailgun {
 	m := MailgunImpl{
-		apiBase:      apiBase,
+		apiBase:      ApiBase,
 		domain:       domain,
 		apiKey:       apiKey,
 		publicApiKey: publicApiKey,

--- a/mailgun.go
+++ b/mailgun.go
@@ -99,6 +99,8 @@ import (
 	"time"
 )
 
+var Debug = false
+
 const (
 	apiBase                 = "https://api.mailgun.net/v3"
 	messagesEndpoint        = "messages"


### PR DESCRIPTION
# Purpose
Provide a simple Mailgun cli for interacting with the Mailgun api. 

Provided
```bash
$ export MG_DOMAIN=my-domain.com
$ export MG_API_KEY=your-api-key
$ export MG_PUBLIC_API_KEY=your-public-api-key
```
This
```bash
$ mailgun send --lorem --count 10 thrawn01@gmail.com derrick@mailgun.com
```
Is much simpler than
```bash
for $i in {1..10}; then
curl -s --user 'api:${MG_API_KEY}' \
    https://api.mailgun.net/v3/${MG_DOMAIN}/messages \
    -F from='Excited User <user@localhost>' \
    -F to=derrick@mailgun.com \
    -F to=thrawn01@gmail.com \
    -F subject='Hello ${i}' \
    -F text='Testing some Mailgun awesomness!'
fi
```
Making a brew formula for this cli would also be pretty simple. Then users could
```bash
$ brew install mailgun-cli
```

# Implementation
Initial release provides a cli with a single sub command called 'send' which initially provides simple sending with tags.

### Mailgun Help
```
Usage:  [OPTIONS]

CLI for mailgun api

Examples:
   Set your credentials in the environment
   export MG_DOMAIN=your-domain-name
   export MG_API_KEY=your-api-key
   export MG_PUBLIC_API_KEY=your-public-api-key

   Post a simple event message from stdin
   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com

 Help:
   For detailed help on send
   $ mailgun send -h

Commands:
  send

Options:
  -v, --verbose          be verbose
  -u, --url              url to the mailgun api (Default=https://api.mailgun.net/v3, Env=MG_URL)
  -a, --api-key          mailgun api key (Env=MG_API_KEY)
  -p, --public-api-key   mailgun public api key (Env=MG_PUBLIC_API_KEY)
  -d, --domain           mailgun api key (Env=MG_DOMAIN)
  -h, --help             Display this help message and exit
```

### Mailgun send help
```
Usage:  [OPTIONS]  <addresses>

Send emails via the mailgun HTTP API

Examples:
   Post a simple email from stdin
   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com

   Post a simple email to a specific domain
   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com -d my-domain.com

   Post a test lorem ipsum email (random content, and subject)
   $ mailgun send --lorem address@example.com

   Post a 10 random test lorem ipsum emails
   $ mailgun send --lorem address@example.com --count 10

Arguments:
  addresses   a list of email addresses

Options:
  -v, --verbose          be verbose
  -u, --url              url to the mailgun api (Default=https://api.mailgun.net/v3, Env=MG_URL)
  -a, --api-key          mailgun api key (Env=MG_API_KEY)
  -p, --public-api-key   mailgun public api key (Env=MG_PUBLIC_API_KEY)
  -d, --domain           mailgun api key (Env=MG_DOMAIN)
  -h, --help             Display this help message and exit
  -s, --subject          subject of the message
  -t, --tags             comma separated list of tags
  -f, --from             from address, defaults to <user>@<hostname> (Env=MG_FROM)
  -l, --lorem            generate a randome subject and message content
  -c, --count            send the email x number of counts (Default=1)
```
