### PR TITLE
added the possibility to set api base URL

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -66,7 +66,7 @@ func (d Domain) GetCreatedAt() (t time.Time, err error) {
 // Note that zero items and a zero-length slice do not necessarily imply an error occurred.
 // Except for the error itself, all results are undefined in the event of an error.
 func (m *MailgunImpl) GetDomains(limit, skip int) (int, []Domain, error) {
-	r := newHTTPRequest(generatePublicApiUrl(domainsEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(m, domainsEndpoint))
 	r.setClient(m.Client())
 	if limit != DefaultLimit {
 		r.addParameter("limit", strconv.Itoa(limit))
@@ -86,7 +86,7 @@ func (m *MailgunImpl) GetDomains(limit, skip int) (int, []Domain, error) {
 
 // Retrieve detailed information about the named domain.
 func (m *MailgunImpl) GetSingleDomain(domain string) (Domain, []DNSRecord, []DNSRecord, error) {
-	r := newHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + domain)
+	r := newHTTPRequest(generatePublicApiUrl(m, domainsEndpoint) + "/" + domain)
 	r.setClient(m.Client())
 	r.setBasicAuth(basicAuthUser, m.ApiKey())
 	var envelope singleDomainEnvelope
@@ -101,7 +101,7 @@ func (m *MailgunImpl) GetSingleDomain(domain string) (Domain, []DNSRecord, []DNS
 // The wildcard parameter instructs Mailgun to treat all subdomains of this domain uniformly if true,
 // and as different domains if false.
 func (m *MailgunImpl) CreateDomain(name string, smtpPassword string, spamAction string, wildcard bool) error {
-	r := newHTTPRequest(generatePublicApiUrl(domainsEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(m, domainsEndpoint))
 	r.setClient(m.Client())
 	r.setBasicAuth(basicAuthUser, m.ApiKey())
 
@@ -116,7 +116,7 @@ func (m *MailgunImpl) CreateDomain(name string, smtpPassword string, spamAction 
 
 // DeleteDomain instructs Mailgun to dispose of the named domain name.
 func (m *MailgunImpl) DeleteDomain(name string) error {
-	r := newHTTPRequest(generatePublicApiUrl(domainsEndpoint) + "/" + name)
+	r := newHTTPRequest(generatePublicApiUrl(m, domainsEndpoint) + "/" + name)
 	r.setClient(m.Client())
 	r.setBasicAuth(basicAuthUser, m.ApiKey())
 	_, err := makeDeleteRequest(r)

--- a/email_validation.go
+++ b/email_validation.go
@@ -40,7 +40,7 @@ type addressParseResult struct {
 // It may also be used to break an email address into its sub-components.  (See example.)
 // NOTE: Use of this function requires a proper public API key.  The private API key will not work.
 func (m *MailgunImpl) ValidateEmail(email string) (EmailVerification, error) {
-	r := newHTTPRequest(generatePublicApiUrl(addressValidateEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(m, addressValidateEndpoint))
 	r.setClient(m.Client())
 	r.addParameter("address", email)
 	r.setBasicAuth(basicAuthUser, m.PublicApiKey())
@@ -57,7 +57,7 @@ func (m *MailgunImpl) ValidateEmail(email string) (EmailVerification, error) {
 // ParseAddresses takes a list of addresses and sorts them into valid and invalid address categories.
 // NOTE: Use of this function requires a proper public API key.  The private API key will not work.
 func (m *MailgunImpl) ParseAddresses(addresses ...string) ([]string, []string, error) {
-	r := newHTTPRequest(generatePublicApiUrl(addressParseEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(m, addressParseEndpoint))
 	r.setClient(m.Client())
 	r.addParameter("addresses", strings.Join(addresses, ","))
 	r.setBasicAuth(basicAuthUser, m.PublicApiKey())

--- a/mailing_lists.go
+++ b/mailing_lists.go
@@ -62,7 +62,7 @@ type Member struct {
 
 // GetLists returns the specified set of mailing lists administered by your account.
 func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, error) {
-	r := newHTTPRequest(generatePublicApiUrl(listsEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(mg, listsEndpoint))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newUrlEncodedPayload()
@@ -93,7 +93,7 @@ func (mg *MailgunImpl) GetLists(limit, skip int, filter string) (int, []List, er
 // If unspecified, Description remains blank,
 // while AccessLevel defaults to Everyone.
 func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
-	r := newHTTPRequest(generatePublicApiUrl(listsEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(mg, listsEndpoint))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newUrlEncodedPayload()
@@ -121,7 +121,7 @@ func (mg *MailgunImpl) CreateList(prototype List) (List, error) {
 // DeleteList removes all current members of the list, then removes the list itself.
 // Attempts to send e-mail to the list will fail subsequent to this call.
 func (mg *MailgunImpl) DeleteList(addr string) error {
-	r := newHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r := newHTTPRequest(generatePublicApiUrl(mg, listsEndpoint) + "/" + addr)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
@@ -131,7 +131,7 @@ func (mg *MailgunImpl) DeleteList(addr string) error {
 // GetListByAddress allows your application to recover the complete List structure
 // representing a mailing list, so long as you have its e-mail address.
 func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
-	r := newHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r := newHTTPRequest(generatePublicApiUrl(mg, listsEndpoint) + "/" + addr)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
@@ -150,7 +150,7 @@ func (mg *MailgunImpl) GetListByAddress(addr string) (List, error) {
 // e-mail sent to the old address will not succeed.
 // Make sure you account for the change accordingly.
 func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
-	r := newHTTPRequest(generatePublicApiUrl(listsEndpoint) + "/" + addr)
+	r := newHTTPRequest(generatePublicApiUrl(mg, listsEndpoint) + "/" + addr)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newUrlEncodedPayload()
@@ -180,7 +180,7 @@ func (mg *MailgunImpl) UpdateList(addr string, prototype List) (List, error) {
 // All indicates that you want both Members and unsubscribed members alike, while
 // Subscribed and Unsubscribed indicate you want only those eponymous subsets.
 func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, []Member, error) {
-	r := newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
+	r := newHTTPRequest(generateMemberApiUrl(mg, listsEndpoint, addr))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newUrlEncodedPayload()
@@ -208,7 +208,7 @@ func (mg *MailgunImpl) GetMembers(limit, skip int, s *bool, addr string) (int, [
 // GetMemberByAddress returns a complete Member structure for a member of a mailing list,
 // given only their subscription e-mail address.
 func (mg *MailgunImpl) GetMemberByAddress(s, l string) (Member, error) {
-	r := newHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
+	r := newHTTPRequest(generateMemberApiUrl(mg, listsEndpoint, l) + "/" + s)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	response, err := makeGetRequest(r)
@@ -231,7 +231,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 		return err
 	}
 
-	r := newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr))
+	r := newHTTPRequest(generateMemberApiUrl(mg, listsEndpoint, addr))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newFormDataPayload()
@@ -249,7 +249,7 @@ func (mg *MailgunImpl) CreateMember(merge bool, addr string, prototype Member) e
 // UpdateMember lets you change certain details about the indicated mailing list member.
 // Address, Name, Vars, and Subscribed fields may be changed.
 func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, error) {
-	r := newHTTPRequest(generateMemberApiUrl(listsEndpoint, l) + "/" + s)
+	r := newHTTPRequest(generateMemberApiUrl(mg, listsEndpoint, l) + "/" + s)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newFormDataPayload()
@@ -282,7 +282,7 @@ func (mg *MailgunImpl) UpdateMember(s, l string, prototype Member) (Member, erro
 
 // DeleteMember removes the member from the list.
 func (mg *MailgunImpl) DeleteMember(member, addr string) error {
-	r := newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + "/" + member)
+	r := newHTTPRequest(generateMemberApiUrl(mg, listsEndpoint, addr) + "/" + member)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
@@ -299,7 +299,7 @@ func (mg *MailgunImpl) DeleteMember(member, addr string) error {
 // Otherwise, each Member needs to have at least the Address field filled out.
 // Other fields are optional, but may be set according to your needs.
 func (mg *MailgunImpl) CreateMemberList(u *bool, addr string, newMembers []interface{}) error {
-	r := newHTTPRequest(generateMemberApiUrl(listsEndpoint, addr) + ".json")
+	r := newHTTPRequest(generateMemberApiUrl(mg, listsEndpoint, addr) + ".json")
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newFormDataPayload()

--- a/routes.go
+++ b/routes.go
@@ -33,7 +33,7 @@ type Route struct {
 // messages sent to a specfic address on your domain.
 // See the Mailgun documentation for more information.
 func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
-	r := newHTTPRequest(generatePublicApiUrl(routesEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(mg, routesEndpoint))
 	if limit != DefaultLimit {
 		r.addParameter("limit", strconv.Itoa(limit))
 	}
@@ -59,7 +59,7 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 // only a subset of the fields influence the operation.
 // See the Route structure definition for more details.
 func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
-	r := newHTTPRequest(generatePublicApiUrl(routesEndpoint))
+	r := newHTTPRequest(generatePublicApiUrl(mg, routesEndpoint))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newUrlEncodedPayload()
@@ -81,7 +81,7 @@ func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 // To avoid ambiguity, Mailgun identifies the route by unique ID.
 // See the Route structure definition and the Mailgun API documentation for more details.
 func (mg *MailgunImpl) DeleteRoute(id string) error {
-	r := newHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r := newHTTPRequest(generatePublicApiUrl(mg, routesEndpoint) + "/" + id)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	_, err := makeDeleteRequest(r)
@@ -90,7 +90,7 @@ func (mg *MailgunImpl) DeleteRoute(id string) error {
 
 // GetRouteByID retrieves the complete route definition associated with the unique route ID.
 func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
-	r := newHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r := newHTTPRequest(generatePublicApiUrl(mg, routesEndpoint) + "/" + id)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	var envelope struct {
@@ -105,7 +105,7 @@ func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 // Only those route fields which are non-zero or non-empty are updated.
 // All other fields remain as-is.
 func (mg *MailgunImpl) UpdateRoute(id string, route Route) (Route, error) {
-	r := newHTTPRequest(generatePublicApiUrl(routesEndpoint) + "/" + id)
+	r := newHTTPRequest(generatePublicApiUrl(mg, routesEndpoint) + "/" + id)
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
 	p := newUrlEncodedPayload()


### PR DESCRIPTION
With this change, it's possible using `httptest` to test the client, for example:

```go
srv := httptest.NewServer(http.HandlerFunc(w http.ResponseWriter, req *http.Request){
// ..test req.Method, req.Path, etc...
}))
defer srv.Close()

client := mg.NewMailgun(domain, apiKey, publicAPIKey)
client.SetClient(http.DefaultClient)
client.SetAPIBase(srv.URL)
rsp, id, err := client.Send(message)
```

And bringing more offline testing options.