### PR TITLE
New event iterator

### DIFF
--- a/cmd/mailgun/main.go
+++ b/cmd/mailgun/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	parser := args.NewParser(args.EnvPrefix("MG_"), args.Desc(desc, args.IsFormated))
 	parser.AddOption("--verbose").Alias("-v").IsTrue().Help("be verbose")
-	parser.AddOption("--url").Alias("-u").Env("URL").Default(mailgun.BaseURL).Help("url to the mailgun api")
+	parser.AddOption("--url").Alias("-u").Env("URL").Default(mailgun.ApiBase).Help("url to the mailgun api")
 	parser.AddOption("--api-key").Alias("-a").Env("API_KEY").Help("mailgun api key")
 	parser.AddOption("--public-api-key").Alias("-p").Env("PUBLIC_API_KEY").Help("mailgun public api key")
 	parser.AddOption("--domain").Alias("-d").Env("DOMAIN").Help("mailgun api key")
@@ -114,13 +114,9 @@ func Send(parser *args.ArgParser, data interface{}) int {
 		opts.Set("from", fmt.Sprintf("%s@%s", os.Getenv("USER"), host))
 	}
 
-	// Read the content from stdin
-	if !opts.Bool("lorem") {
-		// If stdin is not open and character device
-		if !args.IsCharDevice(os.Stdin) {
-			parser.PrintHelp()
-			return 1
-		}
+	// If stdin is not open and character device
+	if args.IsCharDevice(os.Stdin) {
+		// Read the content from stdin
 		content, err = ioutil.ReadAll(os.Stdin)
 		checkErr("Error reading stdin", err)
 	}

--- a/cmd/mailgun/main.go
+++ b/cmd/mailgun/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	parser := args.NewParser(args.EnvPrefix("MG_"), args.Desc(desc, args.IsFormated))
 	parser.AddOption("--verbose").Alias("-v").IsTrue().Help("be verbose")
-	parser.AddOption("--url").Alias("-u").Env("URL").Default(mailgun.ApiBase).Help("url to the mailgun api")
+	parser.AddOption("--url").Alias("-u").Env("URL").Default(mailgun.BaseURL).Help("url to the mailgun api")
 	parser.AddOption("--api-key").Alias("-a").Env("API_KEY").Help("mailgun api key")
 	parser.AddOption("--public-api-key").Alias("-p").Env("PUBLIC_API_KEY").Help("mailgun public api key")
 	parser.AddOption("--domain").Alias("-d").Env("DOMAIN").Help("mailgun api key")
@@ -114,9 +114,13 @@ func Send(parser *args.ArgParser, data interface{}) int {
 		opts.Set("from", fmt.Sprintf("%s@%s", os.Getenv("USER"), host))
 	}
 
-	// If stdin is not open and character device
-	if args.IsCharDevice(os.Stdin) {
-		// Read the content from stdin
+	// Read the content from stdin
+	if !opts.Bool("lorem") {
+		// If stdin is not open and character device
+		if !args.IsCharDevice(os.Stdin) {
+			parser.PrintHelp()
+			return 1
+		}
 		content, err = ioutil.ReadAll(os.Stdin)
 		checkErr("Error reading stdin", err)
 	}

--- a/events_test.go
+++ b/events_test.go
@@ -1,35 +1,123 @@
 package mailgun
 
 import (
-	"testing"
-	"time"
+	"log"
 
 	"github.com/facebookgo/ensure"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-func TestEventIterator(t *testing.T) {
-	mg, err := NewMailgunFromEnv()
-	ensure.Nil(t, err)
+var _ = Describe("ListEvents()", func() {
+	var t GinkgoTInterface
+	var it *EventIterator
+	var mg Mailgun
+	var err error
 
-	// Grab the list of events (as many as we can get)
-	ei := mg.NewEventIterator()
-	err = ei.GetFirstPage(GetEventsOptions{ForceDescending: true})
-	ensure.Nil(t, err)
+	BeforeEach(func() {
+		mg, err = NewMailgunFromEnv()
+		Expect(err).To(BeNil())
+		it = mg.ListEvents(&EventsOptions{Limit: 5})
+	})
 
-	// Print out the kind of event and timestamp.
-	// Specifics about each event will depend on the "event" type.
-	events := ei.Events()
-	t.Log("Event\tTimestamp\t")
-	for _, event := range events {
-		t.Logf("%s\t%s\n", event["event"], time.Unix(int64(event["timestamp"].(float64)), 0))
-	}
-	t.Logf("%d events dumped\n\n", len(events))
-	ensure.True(t, len(events) != 0)
+	Describe("it.Next()", func() {
+		It("Should iterate forward through pages of events", func() {
+			var firstPage, secondPage []Event
 
-	// TODO: (thrawn01) The more I look at this and test it, the more I doubt it will ever work consistently
-	// We're on the first page.  We must at the beginning.
-	/*ei.GetPrevious()
-	if len(ei.Events()) != 0 {
-		t.Fatal("Expected to be at the beginning")
-	}*/
-}
+			ensure.True(t, it.Next(&firstPage))
+			ensure.True(t, it.NextURL != "")
+			ensure.True(t, len(firstPage) != 0)
+			firstIterator := *it
+
+			ensure.True(t, it.Next(&secondPage))
+			ensure.True(t, len(secondPage) != 0)
+
+			// Pages should be different
+			ensure.NotDeepEqual(t, firstPage, secondPage)
+			ensure.True(t, firstIterator.NextURL != it.NextURL)
+			ensure.True(t, firstIterator.PrevURL != it.PrevURL)
+			ensure.Nil(t, it.Err())
+		})
+	})
+
+	Describe("it.Previous()", func() {
+		It("Should iterate backward through pages of events", func() {
+			var firstPage, secondPage, previousPage []Event
+			ensure.True(t, it.Next(&firstPage))
+			ensure.True(t, it.Next(&secondPage))
+
+			ensure.True(t, it.Previous(&previousPage))
+			ensure.True(t, len(previousPage) != 0)
+			ensure.DeepEqual(t, previousPage, firstPage)
+		})
+	})
+
+	Describe("it.First()", func() {
+		It("Should retrieve the first page of events", func() {
+			var firstPage, secondPage []Event
+			ensure.True(t, it.First(&firstPage))
+			ensure.True(t, it.First(&secondPage))
+			ensure.DeepEqual(t, firstPage, secondPage)
+
+			// Calling first resets the iterator to the first page
+			ensure.True(t, it.Next(&secondPage))
+			ensure.NotDeepEqual(t, firstPage, secondPage)
+		})
+	})
+
+	Describe("it.Last()", func() {
+		It("Should retrieve the last page of events", func() {
+			var firstPage, lastPage, previousPage []Event
+			// Calling Last() is invalid unless you first use First() or Next()
+			ensure.False(t, it.Last(&lastPage))
+			ensure.True(t, len(lastPage) == 0)
+
+			ensure.True(t, it.Next(&firstPage))
+			ensure.True(t, len(firstPage) != 0)
+
+			ensure.True(t, it.Last(&lastPage))
+			ensure.True(t, len(lastPage) != 0)
+
+			// Calling first resets the iterator to the first page
+			ensure.True(t, it.Previous(&previousPage))
+			ensure.NotDeepEqual(t, lastPage, previousPage)
+		})
+	})
+})
+
+var _ = Describe("EventIterator()", func() {
+	log := log.New(GinkgoWriter, "EventIterator() - ", 0)
+	var t GinkgoTInterface
+	var mg Mailgun
+	var err error
+
+	BeforeEach(func() {
+		t = GinkgoT()
+		mg, err = NewMailgunFromEnv()
+		ensure.Nil(t, err)
+	})
+
+	Describe("GetFirstPage()", func() {
+		Context("When no parameters are supplied", func() {
+			It("Should return a list of events", func() {
+				ei := mg.NewEventIterator()
+				err := ei.GetFirstPage(GetEventsOptions{})
+				ensure.Nil(t, err)
+
+				// Print out the kind of event and timestamp.
+				// Specifics about each event will depend on the "event" type.
+				events := ei.Events()
+				log.Printf("Event\tTimestamp\t")
+				for _, event := range events {
+					log.Printf("%s\t%v\t\n", event["event"], event["timestamp"])
+				}
+				log.Printf("%d events dumped\n\n", len(events))
+				ensure.True(t, len(events) != 0)
+
+				// TODO: (thrawn01) The more I look at this and test it,
+				// the more I doubt it will ever work consistently
+				//ei.GetPrevious()
+			})
+		})
+	})
+})

--- a/mailgun.go
+++ b/mailgun.go
@@ -206,6 +206,7 @@ type MailgunImpl struct {
 	apiKey       string
 	publicApiKey string
 	client       *http.Client
+	baseURL      string
 }
 
 // NewMailGun creates a new client instance.

--- a/mailgun.go
+++ b/mailgun.go
@@ -195,6 +195,7 @@ type Mailgun interface {
 	NewMessage(from, subject, text string, to ...string) *Message
 	NewMIMEMessage(body io.ReadCloser, to ...string) *Message
 	NewEventIterator() *EventIterator
+	ListEvents(*EventsOptions) *EventIterator
 	SetAPIBase(url string)
 }
 

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -6,11 +6,18 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 const domain = "valid-mailgun-domain"
 const apiKey = "valid-mailgun-api-key"
 const publicApiKey = "valid-mailgun-public-api-key"
+
+func TestMailgunGinkgo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mailgun Test Suite")
+}
 
 func TestMailgun(t *testing.T) {
 	m := NewMailgun(domain, apiKey, publicApiKey)


### PR DESCRIPTION
## Purpose
Implementation for #73.
```go
mg := NewMailgunFromEnv()
it := mg.ListEvents(EventsOptions{})
var events []Event
for it.Next(&events) {
    for _, event := range events {
    // Do things with **events**
    }
}
if it.Err() != nil {
    return "", it.Err()
}
```

## Implementation
* This Pull Request builds upon work done in #69 
* Added `ListEvents(opts *EventsOptions) *EventIterator` to `Mailgun` interface
* Added BDD style tests for the new iterator by introducing ginkgo and gomega to our testing suite
* Added support for `First()` and `Last()` to fetch their respective pages and reset the iterator
* Exposed `FirstURL` , `LastURL`, `PrevURL` and `NextURL` to end users can begin iterating at any point if they already have the appropriate url saved from a previous iteration.