### PR TITLE
Tests now can take advantage of MG_URL and added travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go:
+  - 1.6
+  - 1.7
+
+sudo: false
+
+script:
+    - go get -t .
+    - go test .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Mailgun with Go
 ===============
 
+[![Build Status](https://img.shields.io/travis/mailgun/mailgun-go/master.svg)](https://travis-ci.org/mailgun/mailgun-go)
 [![GoDoc](https://godoc.org/gopkg.in/mailgun/mailgun-go.v1?status.svg)](https://godoc.org/gopkg.in/mailgun/mailgun-go.v1)
 
 

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -6,9 +6,10 @@ import (
 )
 
 func TestGetCredentials(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	n, cs, err := mg.GetCredentials(DefaultLimit, DefaultSkip)
 	if err != nil {
 		t.Fatal(err)
@@ -22,13 +23,15 @@ func TestGetCredentials(t *testing.T) {
 
 func TestCreateDeleteCredentials(t *testing.T) {
 	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	randomPassword := randomString(16, "pw")
 	randomID := randomString(16, "usr")
 	randomLogin := fmt.Sprintf("%s@%s", randomID, domain)
 
-	err := mg.CreateCredential(randomLogin, randomPassword)
+	err = mg.CreateCredential(randomLogin, randomPassword)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/domains_test.go
+++ b/domains_test.go
@@ -5,9 +5,10 @@ import (
 )
 
 func TestGetDomains(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	n, domains, err := mg.GetDomains(DefaultLimit, DefaultSkip)
 	if err != nil {
 		t.Fatal(err)
@@ -19,9 +20,10 @@ func TestGetDomains(t *testing.T) {
 }
 
 func TestGetSingleDomain(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	_, domains, err := mg.GetDomains(DefaultLimit, DefaultSkip)
 	if err != nil {
 		t.Fatal(err)
@@ -41,10 +43,11 @@ func TestGetSingleDomain(t *testing.T) {
 }
 
 func TestGetSingleDomainNotExist(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
-	_, _, _, err := mg.GetSingleDomain(randomString(32, "com.edu.org.") + ".com")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
+	_, _, _, err = mg.GetSingleDomain(randomString(32, "com.edu.org.") + ".com")
 	if err == nil {
 		t.Fatal("Did not expect a domain to exist")
 	}
@@ -58,13 +61,14 @@ func TestGetSingleDomainNotExist(t *testing.T) {
 }
 
 func TestAddDeleteDomain(t *testing.T) {
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	// First, we need to add the domain.
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
 	randomDomainName := randomString(16, "DOMAIN") + ".example.com"
 	randomPassword := randomString(16, "PASSWD")
-	err := mg.CreateDomain(randomDomainName, randomPassword, Tag, false)
+	err = mg.CreateDomain(randomDomainName, randomPassword, Tag, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/email_validation_test.go
+++ b/email_validation_test.go
@@ -5,9 +5,11 @@ import (
 )
 
 func TestEmailValidation(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-	mg := NewMailgun(domain, "", apiKey)
+	reqEnv(t, "MG_PUBLIC_API_KEY")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	ev, err := mg.ValidateEmail("foo@mailgun.com")
 	if err != nil {
 		t.Fatal(err)
@@ -27,10 +29,15 @@ func TestEmailValidation(t *testing.T) {
 }
 
 func TestParseAddresses(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-	mg := NewMailgun(domain, "", apiKey)
-	addressesThatParsed, unparsableAddresses, err := mg.ParseAddresses("Alice <alice@example.com>", "bob@example.com", "example.com")
+	reqEnv(t, "MG_PUBLIC_API_KEY")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
+	addressesThatParsed, unparsableAddresses, err := mg.ParseAddresses(
+		"Alice <alice@example.com>",
+		"bob@example.com",
+		"example.com")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/events_test.go
+++ b/events_test.go
@@ -5,12 +5,14 @@ import (
 )
 
 func TestEventIterator(t *testing.T) {
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
+
 	// Grab the list of events (as many as we can get)
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
 	ei := mg.NewEventIterator()
-	err := ei.GetFirstPage(GetEventsOptions{})
+	err = ei.GetFirstPage(GetEventsOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mailgun.go
+++ b/mailgun.go
@@ -93,9 +93,11 @@
 package mailgun
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -216,6 +218,31 @@ func NewMailgun(domain, apiKey, publicApiKey string) Mailgun {
 		client:       http.DefaultClient,
 	}
 	return &m
+}
+
+// Return a new Mailgun client using the environment variables
+// MG_API_KEY, MG_DOMAIN, MG_PUBLIC_API_KEY and MG_URL
+func NewMailgunFromEnv() (Mailgun, error) {
+	apiKey := os.Getenv("MG_API_KEY")
+	if apiKey == "" {
+		return nil, errors.New("required environment variable MG_API_KEY not defined")
+	}
+	domain := os.Getenv("MG_DOMAIN")
+	if domain == "" {
+		return nil, errors.New("required environment variable MG_DOMAIN not defined")
+	}
+
+	mg := MailgunImpl{
+		domain:       domain,
+		apiKey:       apiKey,
+		publicApiKey: os.Getenv("MG_PUBLIC_API_KEY"),
+		client:       http.DefaultClient,
+	}
+	url := os.Getenv("MG_URL")
+	if url != "" {
+		mg.SetAPIBase(url)
+	}
+	return &mg, nil
 }
 
 // ApiBase returns the API Base URL configured for this client.

--- a/mailing_lists_test.go
+++ b/mailing_lists_test.go
@@ -7,11 +7,13 @@ import (
 
 func setup(t *testing.T) (Mailgun, string) {
 	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 
 	address := fmt.Sprintf("list5@%s", domain)
-	_, err := mg.CreateList(List{
+	_, err = mg.CreateList(List{
 		Address:     address,
 		Name:        address,
 		Description: "TestMailingListMembers-related mailing list",
@@ -133,8 +135,10 @@ func TestMailingListMembers(t *testing.T) {
 
 func TestMailingLists(t *testing.T) {
 	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	listAddr := fmt.Sprintf("list2@%s", domain)
 	protoList := List{
 		Address:     listAddr,
@@ -153,7 +157,7 @@ func TestMailingLists(t *testing.T) {
 
 	startCount := countLists()
 
-	_, err := mg.CreateList(protoList)
+	_, err = mg.CreateList(protoList)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/messages_test.go
+++ b/messages_test.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	fromUser       = "=?utf-8?q?Katie_Brewer=2C_CFP=C2=AE?= <joe@example.com>"
-	exampleSubject = "Joe's Example Subject"
+	exampleSubject = "Mailgun-go Example Subject"
 	exampleText    = "Testing some Mailgun awesomeness!"
 	exampleHtml    = "<html><head /><body><p>Testing some <a href=\"http://google.com?q=abc&r=def&s=ghi\">Mailgun HTML awesomeness!</a> at www.kc5tja@yahoo.com</p></body></html>"
 
@@ -29,10 +29,10 @@ Testing some Mailgun MIME awesomeness!
 func TestSendLegacyPlain(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		msg, id, err := mg.Send(m)
 		if err != nil {
@@ -45,10 +45,10 @@ func TestSendLegacyPlain(t *testing.T) {
 func TestSendLegacyPlainWithTracking(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		m.SetTracking(true)
 		msg, id, err := mg.Send(m)
@@ -62,10 +62,10 @@ func TestSendLegacyPlainWithTracking(t *testing.T) {
 func TestSendLegacyPlainAt(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		m.SetDeliveryTime(time.Now().Add(5 * time.Minute))
 		msg, id, err := mg.Send(m)
@@ -79,10 +79,10 @@ func TestSendLegacyPlainAt(t *testing.T) {
 func TestSendLegacyHtml(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		m.SetHtml(exampleHtml)
 		msg, id, err := mg.Send(m)
@@ -96,10 +96,10 @@ func TestSendLegacyHtml(t *testing.T) {
 func TestSendLegacyTracking(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMessage(fromUser, exampleSubject, exampleText+"Tracking!\n", toUser)
 		m.SetTracking(false)
 		msg, id, err := mg.Send(m)
@@ -113,10 +113,10 @@ func TestSendLegacyTracking(t *testing.T) {
 func TestSendLegacyTag(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMessage(fromUser, exampleSubject, exampleText+"Tags Galore!\n", toUser)
 		m.AddTag("FooTag")
 		m.AddTag("BarTag")
@@ -132,9 +132,10 @@ func TestSendLegacyTag(t *testing.T) {
 func TestSendLegacyMIME(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		mg := NewMailgun(domain, apiKey, "")
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := NewMIMEMessage(ioutil.NopCloser(strings.NewReader(exampleMime)), toUser)
 		msg, id, err := mg.Send(m)
 		if err != nil {
@@ -146,9 +147,10 @@ func TestSendLegacyMIME(t *testing.T) {
 
 func TestGetStoredMessage(t *testing.T) {
 	spendMoney(t, func() {
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		mg := NewMailgun(domain, apiKey, "")
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		id, err := findStoredMessageID(mg) // somehow...
 		if err != nil {
 			t.Log(err)
@@ -205,10 +207,10 @@ func findStoredMessageID(mg Mailgun) (string, error) {
 func TestSendMGPlain(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		msg, id, err := mg.Send(m)
 		if err != nil {
@@ -221,10 +223,10 @@ func TestSendMGPlain(t *testing.T) {
 func TestSendMGPlainWithTracking(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		m.SetTracking(true)
 		msg, id, err := mg.Send(m)
@@ -238,10 +240,10 @@ func TestSendMGPlainWithTracking(t *testing.T) {
 func TestSendMGPlainAt(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		m.SetDeliveryTime(time.Now().Add(5 * time.Minute))
 		msg, id, err := mg.Send(m)
@@ -255,10 +257,10 @@ func TestSendMGPlainAt(t *testing.T) {
 func TestSendMGHtml(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText, toUser)
 		m.SetHtml(exampleHtml)
 		msg, id, err := mg.Send(m)
@@ -272,10 +274,10 @@ func TestSendMGHtml(t *testing.T) {
 func TestSendMGTracking(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText+"Tracking!\n", toUser)
 		m.SetTracking(false)
 		msg, id, err := mg.Send(m)
@@ -289,10 +291,10 @@ func TestSendMGTracking(t *testing.T) {
 func TestSendMGTag(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-		mg := NewMailgun(domain, apiKey, publicApiKey)
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText+"Tags Galore!\n", toUser)
 		m.AddTag("FooTag")
 		m.AddTag("BarTag")
@@ -308,9 +310,10 @@ func TestSendMGTag(t *testing.T) {
 func TestSendMGMIME(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		mg := NewMailgun(domain, apiKey, "")
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMIMEMessage(ioutil.NopCloser(strings.NewReader(exampleMime)), toUser)
 		msg, id, err := mg.Send(m)
 		if err != nil {
@@ -323,14 +326,15 @@ func TestSendMGMIME(t *testing.T) {
 func TestSendMGBatchFailRecipients(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		mg := NewMailgun(domain, apiKey, "")
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, exampleText+"Batch\n")
 		for i := 0; i < MaxNumberOfRecipients; i++ {
 			m.AddRecipient("") // We expect this to indicate a failure at the API
 		}
-		err := m.AddRecipientAndVariables(toUser, nil)
+		err = m.AddRecipientAndVariables(toUser, nil)
 		if err == nil {
 			// If we're here, either the SDK didn't send the message,
 			// OR the API didn't check for empty To: headers.
@@ -342,11 +346,12 @@ func TestSendMGBatchFailRecipients(t *testing.T) {
 func TestSendMGBatchRecipientVariables(t *testing.T) {
 	spendMoney(t, func() {
 		toUser := reqEnv(t, "MG_EMAIL_TO")
-		domain := reqEnv(t, "MG_DOMAIN")
-		apiKey := reqEnv(t, "MG_API_KEY")
-		mg := NewMailgun(domain, apiKey, "")
+		mg, err := NewMailgunFromEnv()
+		if err != nil {
+			t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+		}
 		m := mg.NewMessage(fromUser, exampleSubject, templateText)
-		err := m.AddRecipientAndVariables(toUser, map[string]interface{}{
+		err = m.AddRecipientAndVariables(toUser, map[string]interface{}{
 			"name":  "Joe Cool Example",
 			"table": 42,
 		})

--- a/routes.go
+++ b/routes.go
@@ -1,6 +1,7 @@
 package mailgun
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -42,13 +43,13 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 	}
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
-
 	var envelope struct {
 		TotalCount int     `json:"total_count"`
 		Items      []Route `json:"items"`
 	}
 	err := getResponseFromJSON(r, &envelope)
 	if err != nil {
+		fmt.Printf("err here\n")
 		return -1, nil, err
 	}
 	return envelope.TotalCount, envelope.Items, nil

--- a/routes_test.go
+++ b/routes_test.go
@@ -5,9 +5,10 @@ import (
 )
 
 func TestRouteCRUD(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 
 	var countRoutes = func() int {
 		count, _, err := mg.GetRoutes(DefaultLimit, DefaultSkip)

--- a/spam_complaints_test.go
+++ b/spam_complaints_test.go
@@ -5,10 +5,11 @@ import (
 )
 
 func TestGetComplaints(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-	mg := NewMailgun(domain, apiKey, publicApiKey)
+	reqEnv(t, "MG_PUBLIC_API_KEY")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	n, complaints, err := mg.GetComplaints(-1, -1)
 	if err != nil {
 		t.Fatal(err)
@@ -19,11 +20,12 @@ func TestGetComplaints(t *testing.T) {
 }
 
 func TestGetComplaintFromRandomNoComplaint(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	publicApiKey := reqEnv(t, "MG_PUBLIC_API_KEY")
-	mg := NewMailgun(domain, apiKey, publicApiKey)
-	_, err := mg.GetSingleComplaint(randomString(64, "") + "@example.com")
+	reqEnv(t, "MG_PUBLIC_API_KEY")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
+	_, err = mg.GetSingleComplaint(randomString(64, "") + "@example.com")
 	if err == nil {
 		t.Fatal("Expected not-found error for missing complaint")
 	}
@@ -37,9 +39,10 @@ func TestGetComplaintFromRandomNoComplaint(t *testing.T) {
 }
 
 func TestCreateDeleteComplaint(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	var check = func(count int) int {
 		c, _, err := mg.GetComplaints(DefaultLimit, DefaultSkip)
 		if err != nil {
@@ -55,7 +58,7 @@ func TestCreateDeleteComplaint(t *testing.T) {
 	randomMail := randomString(64, "") + "@example.com"
 
 	origCount := check(-1)
-	err := mg.CreateComplaint(randomMail)
+	err = mg.CreateComplaint(randomMail)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -5,9 +5,10 @@ import (
 )
 
 func TestGetStats(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 
 	totalCount, stats, err := mg.GetStats(-1, -1, nil, "sent", "opened")
 	if err != nil {
@@ -22,10 +23,11 @@ func TestGetStats(t *testing.T) {
 }
 
 func TestDeleteTag(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
-	err := mg.DeleteTag("newsletter")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
+	err = mg.DeleteTag("newsletter")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/unsubscribes_test.go
+++ b/unsubscribes_test.go
@@ -5,22 +5,24 @@ import (
 )
 
 func TestCreateUnsubscriber(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
 	email := reqEnv(t, "MG_EMAIL_ADDR")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 
 	// Create unsubscription record
-	err := mg.Unsubscribe(email, "*")
+	err = mg.Unsubscribe(email, "*")
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestGetUnsubscribes(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	n, us, err := mg.GetUnsubscribes(DefaultLimit, DefaultSkip)
 	if err != nil {
 		t.Fatal(err)
@@ -35,10 +37,11 @@ func TestGetUnsubscribes(t *testing.T) {
 }
 
 func TestGetUnsubscriptionByAddress(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
 	email := reqEnv(t, "MG_EMAIL_ADDR")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 	n, us, err := mg.GetUnsubscribesByAddress(email)
 	if err != nil {
 		t.Fatal(err)
@@ -53,13 +56,14 @@ func TestGetUnsubscriptionByAddress(t *testing.T) {
 }
 
 func TestCreateDestroyUnsubscription(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
 	email := reqEnv(t, "MG_EMAIL_ADDR")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 
 	// Create unsubscription record
-	err := mg.Unsubscribe(email, "*")
+	err = mg.Unsubscribe(email, "*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -5,9 +5,10 @@ import (
 )
 
 func TestWebhookCRUD(t *testing.T) {
-	domain := reqEnv(t, "MG_DOMAIN")
-	apiKey := reqEnv(t, "MG_API_KEY")
-	mg := NewMailgun(domain, apiKey, "")
+	mg, err := NewMailgunFromEnv()
+	if err != nil {
+		t.Fatalf("NewMailgunFromEnv() error - %s", err.Error())
+	}
 
 	var countHooks = func() int {
 		hooks, err := mg.GetWebhooks()
@@ -19,7 +20,7 @@ func TestWebhookCRUD(t *testing.T) {
 
 	hookCount := countHooks()
 
-	err := mg.CreateWebhook("deliver", "http://www.example.com")
+	err = mg.CreateWebhook("deliver", "http://www.example.com")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Purpose
To allow tests to run against a different url than api.mailgun.net and to enable travis-ci for pull requests

# Implementation
Added `.travis.yml`
Replaced `NewMailgun()` with `NewMailgunFromEnv()` in tests