### PR TITLE
TestEventIterator should now pass consistently

### DIFF
--- a/events_test.go
+++ b/events_test.go
@@ -12,7 +12,7 @@ func TestEventIterator(t *testing.T) {
 
 	// Grab the list of events (as many as we can get)
 	ei := mg.NewEventIterator()
-	err = ei.GetFirstPage(GetEventsOptions{})
+	err = ei.GetFirstPage(GetEventsOptions{ForceDescending: true})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Purpose
To improve the odds the event test will pass

# Implementation
Events pulled should now come from the oldest of events, instead of the newest.