### PR TITLE
No longer checking for route count after delete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ go:
 sudo: false
 
 script:
-    - go get -t .
-    - go test .
+    - make

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: all
+.DEFAULT_GOAL := all
+
+all:
+# Only run these tests if secure credentials exist
+ifeq ($(TRAVIS_SECURE_ENV_VARS),true)
+	go get -t .
+	go test .
+endif

--- a/routes.go
+++ b/routes.go
@@ -99,7 +99,11 @@ func (mg *MailgunImpl) GetRouteByID(id string) (Route, error) {
 		*Route  `json:"route"`
 	}
 	err := getResponseFromJSON(r, &envelope)
+	if err != nil {
+		return Route{}, err
+	}
 	return *envelope.Route, err
+
 }
 
 // UpdateRoute provides an "in-place" update of the specified route.

--- a/routes_test.go
+++ b/routes_test.go
@@ -36,14 +36,14 @@ func TestRouteCRUD(t *testing.T) {
 		t.Fatal("I expected the route created to have an ID associated with it.")
 	}
 	defer func() {
-		err = mg.DeleteRoute(newRoute.ID)
+		err := mg.DeleteRoute(newRoute.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		newCount := countRoutes()
-		if newCount != routeCount {
-			t.Fatalf("Expected %d routes defined; got %d", routeCount, newCount)
+		_, err = mg.GetRouteByID(newRoute.ID)
+		if err == nil {
+			t.Fatalf("Expected route %d deleted", newRoute.ID)
 		}
 	}()
 


### PR DESCRIPTION
# Purpose
During CI it is possible 2 tests are running simultaneously, for the routes test this may mean the routes list is not empty. 

# Implementation
Refrain from using countRoutes() after deleting the test route 