### PR TITLE
GetUnsubscribes response returns 'tags', not 'tag'

### DIFF
--- a/unsubscribes.go
+++ b/unsubscribes.go
@@ -5,10 +5,10 @@ import (
 )
 
 type Unsubscription struct {
-	CreatedAt string `json:"created_at"`
-	Tag       string `json:"tag"`
-	ID        string `json:"id"`
-	Address   string `json:"address"`
+	CreatedAt string   `json:"created_at"`
+	Tags      []string `json:"tags"`
+	ID        string   `json:"id"`
+	Address   string   `json:"address"`
 }
 
 // GetUnsubscribes retrieves a list of unsubscriptions issued by recipients of mail from your domain.

--- a/unsubscribes_test.go
+++ b/unsubscribes_test.go
@@ -23,9 +23,9 @@ func TestGetUnsubscribes(t *testing.T) {
 
 	t.Logf("Received %d out of %d unsubscribe records.\n", len(us), n)
 	if len(us) > 0 {
-		t.Log("ID\tAddress\tCreated At\tTag\t")
+		t.Log("ID\tAddress\tCreated At\tTags\t")
 		for _, u := range us {
-			t.Logf("%s\t%s\t%s\t%s\t\n", u.ID, u.Address, u.CreatedAt, u.Tag)
+			t.Logf("%s\t%s\t%s\t%s\t\n", u.ID, u.Address, u.CreatedAt, u.Tags)
 		}
 	}
 }
@@ -43,9 +43,9 @@ func TestGetUnsubscriptionByAddress(t *testing.T) {
 
 	t.Logf("Received %d out of %d unsubscribe records.\n", len(us), n)
 	if len(us) > 0 {
-		t.Log("ID\tAddress\tCreated At\tTag\t")
+		t.Log("ID\tAddress\tCreated At\tTags\t")
 		for _, u := range us {
-			t.Logf("%s\t%s\t%s\t%s\t\n", u.ID, u.Address, u.CreatedAt, u.Tag)
+			t.Logf("%s\t%s\t%s\t%s\t\n", u.ID, u.Address, u.CreatedAt, u.Tags)
 		}
 	}
 	// Destroy the unsubscription record


### PR DESCRIPTION
Noticed that the `.Tag` field was consistently empty for `Unsubscribe` structs returned by `.GetUnsubscribes()`, and after a bit of investigating, it looks like the JSON returned by the API call specifies a string array of `"tags"`, not a single string `"tag"`.