### PR TITLE
Add PollEvents() to Mailgun interface

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -15,11 +15,12 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
+	"github.com/onsi/ginkgo"
 )
 
 // Many tests require configuration settings unique to the user, passed in via
 // environment variables.  If these variables aren't set, we need to fail the test early.
-func reqEnv(t *testing.T, variableName string) string {
+func reqEnv(t ginkgo.GinkgoTInterface, variableName string) string {
 	value := os.Getenv(variableName)
 	ensure.True(t, value != "")
 	return value

--- a/mailgun.go
+++ b/mailgun.go
@@ -196,6 +196,7 @@ type Mailgun interface {
 	NewMIMEMessage(body io.ReadCloser, to ...string) *Message
 	NewEventIterator() *EventIterator
 	ListEvents(*EventsOptions) *EventIterator
+	PollEvents(*EventsOptions) *EventPoller
 	SetAPIBase(url string)
 }
 


### PR DESCRIPTION
## Purpose
Provide an simple interface for users to poll the event api for new events as they happen
This PR fulfills issue #75
```go
mg := mailgun.NewMailgunFromEnv()
it = mg.PollEvents(&EventsOptions{
	// Poll() returns after this threshold is met
        // or events older than this threshold appear
	ThresholdAge: time.Minute * 1,
	// Only events with a timestamp after this date/time will be returned
	Begin: time.Now().Add(time.Minute * -1),
	// How often we poll the api for new events
	PollInterval: time.Seconds * 30})
var events []Event
// Blocks until new events appear
for it.Poll(&events) {
	for _, event := range(events) {
		fmt.Printf("Event %+v\n", event)
	}
}
```

## Implementation
* Used the new `EventIterator` to Implement event polling as described in the mailgun docs [here](https://documentation.mailgun.com/api-events.html#event-polling)
* Added `ParseTimeStamp()` and `ParseMessageId()` to the `Event` struct as convenience methods