### PR TITLE
Improved Tag Support and add 'tag' subcommand CLI

### DIFF
--- a/cmd/mailgun/main.go
+++ b/cmd/mailgun/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
-	"github.com/drhodes/golorem"
 	"github.com/mailgun/log"
 	"github.com/mailgun/mailgun-go"
 	"github.com/thrawn01/args"
@@ -37,13 +35,14 @@ func main() {
 
 	parser := args.NewParser(args.EnvPrefix("MG_"), args.Desc(desc, args.IsFormated))
 	parser.AddOption("--verbose").Alias("-v").IsTrue().Help("be verbose")
-	parser.AddOption("--url").Alias("-u").Env("URL").Default(mailgun.ApiBase).Help("url to the mailgun api")
-	parser.AddOption("--api-key").Alias("-a").Env("API_KEY").Help("mailgun api key")
-	parser.AddOption("--public-api-key").Alias("-p").Env("PUBLIC_API_KEY").Help("mailgun public api key")
-	parser.AddOption("--domain").Alias("-d").Env("DOMAIN").Help("mailgun api key")
+	parser.AddOption("--url").Env("URL").Default(mailgun.ApiBase).Help("url to the mailgun api")
+	parser.AddOption("--api-key").Env("API_KEY").Help("mailgun api key")
+	parser.AddOption("--public-api-key").Env("PUBLIC_API_KEY").Help("mailgun public api key")
+	parser.AddOption("--domain").Env("DOMAIN").Help("mailgun api key")
 
 	// Commands
 	parser.AddCommand("send", Send)
+	parser.AddCommand("tag", Tag)
 
 	// Parser and set global options
 	opts := parser.ParseArgsSimple(nil)
@@ -67,88 +66,4 @@ func main() {
 		os.Exit(1)
 	}
 	os.Exit(retCode)
-}
-
-func Send(parser *args.ArgParser, data interface{}) int {
-	mg := data.(mailgun.Mailgun)
-	var content []byte
-	var err error
-	var count int
-
-	log.InitWithConfig(log.Config{Name: "console"})
-	desc := args.Dedent(`Send emails via the mailgun HTTP API
-
-	Examples:
-	   Post a simple email from stdin
-	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com
-
-	   Post a simple email to a specific domain
-	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com -d my-domain.com
-
-	   Post a test lorem ipsum email (random content, and subject)
-	   $ mailgun send --lorem address@example.com
-
-	   Post a 10 random test lorem ipsum emails
-	   $ mailgun send --lorem address@example.com --count 10`)
-
-	parser.SetDesc(desc)
-	parser.AddOption("--subject").Alias("-s").Help("subject of the message")
-	parser.AddOption("--tags").IsStringSlice().Alias("-t").Help("comma separated list of tags")
-	parser.AddOption("--from").Alias("-f").Env("FROM").Help("from address, defaults to <user>@<hostname>")
-	parser.AddOption("--lorem").Alias("-l").IsTrue().Help("generate a randome subject and message content")
-	parser.AddOption("--count").StoreInt(&count).Default("1").Alias("-c").Help("send the email x number of counts")
-	parser.AddArgument("addresses").IsStringSlice().Required().Help("a list of email addresses")
-
-	opts := parser.ParseArgsSimple(nil)
-
-	// Required for send
-	if err := opts.Required([]string{"domain", "api-key"}); err != nil {
-		fmt.Fprintf(os.Stderr, "Missing Required option '%s'", err)
-		return 1
-	}
-
-	// Default to user@hostname if no from address provided
-	if !opts.IsSet("from") {
-		host, err := os.Hostname()
-		checkErr("Hostname Error", err)
-		opts.Set("from", fmt.Sprintf("%s@%s", os.Getenv("USER"), host))
-	}
-
-	// If stdin is not open and character device
-	if args.IsCharDevice(os.Stdin) {
-		// Read the content from stdin
-		content, err = ioutil.ReadAll(os.Stdin)
-		checkErr("Error reading stdin", err)
-	}
-
-	subject := opts.String("subject")
-
-	if opts.Bool("lorem") {
-		if len(subject) == 0 {
-			subject = lorem.Sentence(3, 5)
-		}
-		if len(content) == 0 {
-			content = []byte(lorem.Paragraph(10, 50))
-		}
-	} else {
-		if len(content) == 0 {
-			fmt.Fprintln(os.Stderr, "Must provide email body, or use --lorem")
-			os.Exit(1)
-		}
-		if len(subject) == 0 {
-			fmt.Fprintln(os.Stderr, "Must provide subject, or use --lorem")
-			os.Exit(1)
-		}
-	}
-
-	for i := 0; i < count; i++ {
-		resp, id, err := mg.Send(mg.NewMessage(
-			opts.String("from"),
-			subject,
-			string(content),
-			opts.StringSlice("addresses")...))
-		checkErr("Message Error", err)
-		fmt.Printf("Id: %s Resp: %s\n", id, resp)
-	}
-	return 0
 }

--- a/cmd/mailgun/send.go
+++ b/cmd/mailgun/send.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/drhodes/golorem"
+	"github.com/mailgun/log"
+	"github.com/mailgun/mailgun-go"
+	"github.com/thrawn01/args"
+)
+
+func Send(parser *args.ArgParser, data interface{}) int {
+	mg := data.(mailgun.Mailgun)
+	var content []byte
+	var err error
+	var count int
+
+	log.InitWithConfig(log.Config{Name: "console"})
+	desc := args.Dedent(`Send emails via the mailgun HTTP API
+
+	Examples:
+	   Post a simple email from stdin
+	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com
+
+	   Post a simple email to a specific domain
+	   $ echo -n 'Hello World' | mailgun send -s "Test subject" address@example.com -d my-domain.com
+
+	   Post a test lorem ipsum email (random content, and subject)
+	   $ mailgun send --lorem address@example.com
+
+	   Post a 10 random test lorem ipsum emails
+	   $ mailgun send --lorem address@example.com --count 10`)
+
+	parser.SetDesc(desc)
+	parser.AddOption("--subject").Alias("-s").Help("subject of the message")
+	parser.AddOption("--tags").IsStringSlice().Alias("-t").Help("comma separated list of tags")
+	parser.AddOption("--from").Alias("-f").Env("FROM").Help("from address, defaults to <user>@<hostname>")
+	parser.AddOption("--lorem").Alias("-l").IsTrue().Help("generate a randome subject and message content")
+	parser.AddOption("--count").StoreInt(&count).Default("1").Alias("-c").Help("send the email x number of counts")
+	parser.AddArgument("addresses").IsStringSlice().Required().Help("a list of email addresses")
+
+	opts := parser.ParseArgsSimple(nil)
+
+	// Required for send
+	if err := opts.Required([]string{"domain", "api-key"}); err != nil {
+		fmt.Fprintf(os.Stderr, "Missing Required option '%s'", err)
+		return 1
+	}
+
+	// Default to user@hostname if no from address provided
+	if !opts.IsSet("from") {
+		host, err := os.Hostname()
+		checkErr("Hostname Error", err)
+		opts.Set("from", fmt.Sprintf("%s@%s", os.Getenv("USER"), host))
+	}
+
+	// If stdin is not open and character device
+	if args.IsCharDevice(os.Stdin) {
+		// Read the content from stdin
+		content, err = ioutil.ReadAll(os.Stdin)
+		checkErr("Error reading stdin", err)
+	}
+
+	subject := opts.String("subject")
+
+	if opts.Bool("lorem") {
+		if len(subject) == 0 {
+			subject = lorem.Sentence(3, 5)
+		}
+		if len(content) == 0 {
+			content = []byte(lorem.Paragraph(10, 50))
+		}
+	} else {
+		if len(content) == 0 {
+			fmt.Fprintln(os.Stderr, "Must provide email body, or use --lorem")
+			os.Exit(1)
+		}
+		if len(subject) == 0 {
+			fmt.Fprintln(os.Stderr, "Must provide subject, or use --lorem")
+			os.Exit(1)
+		}
+	}
+
+	for i := 0; i < count; i++ {
+		resp, id, err := mg.Send(mg.NewMessage(
+			opts.String("from"),
+			subject,
+			string(content),
+			opts.StringSlice("addresses")...))
+		checkErr("Message Error", err)
+		fmt.Printf("Id: %s Resp: %s\n", id, resp)
+	}
+	return 0
+}

--- a/cmd/mailgun/send.go
+++ b/cmd/mailgun/send.go
@@ -83,12 +83,24 @@ func Send(parser *args.ArgParser, data interface{}) int {
 		}
 	}
 
+	var tags []string
+	if opts.IsSet("tags") {
+		tags = opts.StringSlice("tags")
+	}
+
 	for i := 0; i < count; i++ {
-		resp, id, err := mg.Send(mg.NewMessage(
+		msg := mg.NewMessage(
 			opts.String("from"),
 			subject,
 			string(content),
-			opts.StringSlice("addresses")...))
+			opts.StringSlice("addresses")...)
+
+		// Add any tags if provided
+		for _, tag := range tags {
+			msg.AddTag(tag)
+		}
+
+		resp, id, err := mg.Send(msg)
 		checkErr("Message Error", err)
 		fmt.Printf("Id: %s Resp: %s\n", id, resp)
 	}

--- a/cmd/mailgun/tag.go
+++ b/cmd/mailgun/tag.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"encoding/json"
+
+	"github.com/mailgun/log"
+	"github.com/mailgun/mailgun-go"
+	"github.com/thrawn01/args"
+)
+
+func Tag(parser *args.ArgParser, data interface{}) int {
+	mg := data.(mailgun.Mailgun)
+	var err error
+
+	log.InitWithConfig(log.Config{Name: "console"})
+	desc := args.Dedent(`Manage tags via the mailgun HTTP API
+
+	Examples:
+	   list all available tags
+	   $ mailgun tag list
+
+	   list tags with a specific prefix
+	   $ mailgun tag list -p foo
+
+	   get a single tag
+	   $ mailgun tag get my-tag
+
+	   delete a tag
+	   $ mailgun tag delete my-tag`)
+
+	parser.SetDesc(desc)
+
+	// Commands
+	parser.AddCommand("list", ListTag)
+	parser.AddCommand("get", GetTag)
+	parser.AddCommand("delete", DeleteTag)
+
+	// Parse the subcommands
+	parser.ParseArgsSimple(nil)
+
+	// Run the command chosen by our user
+	retCode, err := parser.RunCommand(mg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		return 1
+	}
+	return retCode
+}
+
+func ListTag(parser *args.ArgParser, data interface{}) int {
+	mg := data.(mailgun.Mailgun)
+
+	desc := args.Dedent(`list tags via the mailgun HTTP API
+
+	Examples:
+	   list all available tags
+	   $ mailgun tag list
+
+	   list the first 2,000 tags
+	   $ mailgun tag list -l 2000
+
+	   list tags with a specific prefix
+	   $ mailgun tag list -p foo`)
+	parser.SetDesc(desc)
+	parser.AddOption("--prefix").Alias("-p").Help("list only tags with the given prefix")
+	parser.AddOption("--limit").Alias("-l").IsInt().Help("Limit the result set")
+	parser.AddOption("--tag").Alias("-t").Help("The tag that marks piviot point for the --page parameter")
+	parser.AddOption("--page").Alias("-pg").
+		Help("The page direction based off the tag parameter; valid choices are (first, last, next, prev)")
+
+	opts := parser.ParseArgsSimple(nil)
+
+	// Calculate our request limit
+	limit := opts.Int("limit")
+
+	// Create the tag iterator
+	it := mg.ListTags(&mailgun.TagOptions{
+		Limit:  limit,
+		Prefix: opts.String("prefix"),
+		Page:   opts.String("page"),
+		Tag:    opts.String("tag"),
+	})
+
+	var count int
+	var page mailgun.TagsPage
+	for it.Next(&page) {
+		for _, tag := range page.Items {
+			fmt.Printf("%s\n", tag.Value)
+			count += 1
+			if limit != 0 && count > limit {
+				return 0
+			}
+		}
+	}
+	return 0
+}
+
+func GetTag(parser *args.ArgParser, data interface{}) int {
+	mg := data.(mailgun.Mailgun)
+
+	desc := args.Dedent(`get metatdata about a tag via the mailgun HTTP API
+
+	Examples:
+	   fetch the tag metatdata and print it in json
+	   $ mailgun tag get my-tag`)
+	parser.SetDesc(desc)
+	parser.AddArgument("tag").Required().Help("the tag to retrieve")
+
+	opts := parser.ParseArgsSimple(nil)
+
+	tag, err := mg.GetTag(opts.String("tag"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return 1
+	}
+	output, err := json.Marshal(tag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Json Error: %s\n", err)
+		return 1
+	}
+	fmt.Print(string(output))
+	return 0
+}
+
+func DeleteTag(parser *args.ArgParser, data interface{}) int {
+	mg := data.(mailgun.Mailgun)
+
+	desc := args.Dedent(`delete a tag via the mailgun HTTP API
+
+	Examples:
+	   delete my-tag
+	   $ mailgun tag delete my-tag`)
+	parser.SetDesc(desc)
+	parser.AddArgument("tag").Required().Help("the tag to delete")
+
+	opts := parser.ParseArgsSimple(nil)
+
+	err := mg.DeleteTag(opts.String("tag"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return 1
+	}
+	return 0
+}

--- a/mailgun.go
+++ b/mailgun.go
@@ -112,7 +112,7 @@ const (
 	bouncesEndpoint         = "bounces"
 	statsEndpoint           = "stats"
 	domainsEndpoint         = "domains"
-	deleteTagEndpoint       = "tags"
+	tagsEndpoint            = "tags"
 	campaignsEndpoint       = "campaigns"
 	eventsEndpoint          = "events"
 	credentialsEndpoint     = "credentials"
@@ -146,7 +146,9 @@ type Mailgun interface {
 	AddBounce(address, code, error string) error
 	DeleteBounce(address string) error
 	GetStats(limit int, skip int, startDate *time.Time, event ...string) (int, []Stat, error)
+	GetTag(tag string) (TagItem, error)
 	DeleteTag(tag string) error
+	ListTags(*TagOptions) *TagIterator
 	GetDomains(limit, skip int) (int, []Domain, error)
 	GetSingleDomain(domain string) (Domain, []DNSRecord, []DNSRecord, error)
 	CreateDomain(name string, smtpPassword string, spamAction string, wildcard bool) error

--- a/rest_shim.go
+++ b/rest_shim.go
@@ -151,3 +151,12 @@ func makeDeleteRequest(r *httpRequest) (*httpResponse, error) {
 	}
 	return rsp, err
 }
+
+// Extract the http status code from error object
+func GetStatusFromErr(err error) int {
+	obj, ok := err.(*UnexpectedResponseError)
+	if !ok {
+		return -1
+	}
+	return obj.Actual
+}

--- a/stats.go
+++ b/stats.go
@@ -51,12 +51,3 @@ func (m *MailgunImpl) GetStats(limit int, skip int, startDate *time.Time, event 
 		return res.TotalCount, res.Items, nil
 	}
 }
-
-// DeleteTag removes all counters for a particular tag, including the tag itself.
-func (m *MailgunImpl) DeleteTag(tag string) error {
-	r := newHTTPRequest(generateApiUrl(m, deleteTagEndpoint) + "/" + tag)
-	r.setClient(m.Client())
-	r.setBasicAuth(basicAuthUser, m.ApiKey())
-	_, err := makeDeleteRequest(r)
-	return err
-}

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,177 @@
+package mailgun
+
+import (
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type TagItem struct {
+	Value       string     `json:"tag"`
+	Description string     `json:"description"`
+	FirstSeen   *time.Time `json:"first-seen,omitempty"`
+	LastSeen    *time.Time `json:"last-seen,omitempty"`
+}
+
+type TagsPage struct {
+	Items  []TagItem `json:"items"`
+	Paging Paging    `json:"paging"`
+}
+
+type TagOptions struct {
+	// Restrict the page size to this limit
+	Limit int
+	// Return only the tags starting with the given prefix
+	Prefix string
+	// The page direction based off the 'tag' parameter; valid choices are (first, last, next, prev)
+	Page string
+	// The tag that marks piviot point for the 'page' parameter
+	Tag string
+}
+
+// DeleteTag removes all counters for a particular tag, including the tag itself.
+func (m *MailgunImpl) DeleteTag(tag string) error {
+	r := newHTTPRequest(generateApiUrl(m, tagsEndpoint) + "/" + tag)
+	r.setClient(m.Client())
+	r.setBasicAuth(basicAuthUser, m.ApiKey())
+	_, err := makeDeleteRequest(r)
+	return err
+}
+
+// GetTag retrieves metadata about the tag from the api
+func (m *MailgunImpl) GetTag(tag string) (TagItem, error) {
+	r := newHTTPRequest(generateApiUrl(m, tagsEndpoint) + "/" + tag)
+	r.setClient(m.Client())
+	r.setBasicAuth(basicAuthUser, m.ApiKey())
+	var tagItem TagItem
+	return tagItem, getResponseFromJSON(r, &tagItem)
+}
+
+// ListTags returns a cursor used to iterate through a list of tags
+//	it := mg.ListTags(nil)
+//	var page TagsPage
+//	for it.Next(&page) {
+//		for _, tag := range(page.Items) {
+//			// Do stuff with tags
+//		}
+//	}
+//	if it.Err() != nil {
+//		log.Fatal(it.Err())
+//	}
+func (m *MailgunImpl) ListTags(opts *TagOptions) *TagIterator {
+	req := newHTTPRequest(generateApiUrl(m, tagsEndpoint))
+	if opts != nil {
+		if opts.Limit != 0 {
+			req.addParameter("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Prefix != "" {
+			req.addParameter("prefix", opts.Prefix)
+		}
+		if opts.Page != "" {
+			req.addParameter("page", opts.Page)
+		}
+		if opts.Tag != "" {
+			req.addParameter("tag", opts.Tag)
+		}
+	}
+
+	initialUrl, _ := req.generateUrlWithParameters()
+	tagPage := TagsPage{
+		Paging: Paging{
+			First:    initialUrl,
+			Next:     initialUrl,
+			Last:     initialUrl,
+			Previous: initialUrl,
+		},
+	}
+	return NewTagCursor(tagPage, m)
+}
+
+type TagIterator struct {
+	mg   Mailgun
+	curr TagsPage
+	err  error
+}
+
+// Creates a new cursor from a taglist
+func NewTagCursor(tagPage TagsPage, mailgun Mailgun) *TagIterator {
+	return &TagIterator{curr: tagPage, mg: mailgun}
+}
+
+// Returns the next page in the list of tags
+func (t *TagIterator) Next(tagPage *TagsPage) bool {
+	if !canFetchPage(t.curr.Paging.Next) {
+		return false
+	}
+
+	if err := t.cursorRequest(tagPage, t.curr.Paging.Next); err != nil {
+		t.err = err
+		return false
+	}
+	t.curr = *tagPage
+	return true
+}
+
+// Returns the previous page in the list of tags
+func (t *TagIterator) Previous(tagPage *TagsPage) bool {
+	if !canFetchPage(t.curr.Paging.Previous) {
+		return false
+	}
+
+	if err := t.cursorRequest(tagPage, t.curr.Paging.Previous); err != nil {
+		t.err = err
+		return false
+	}
+	t.curr = *tagPage
+	return true
+}
+
+// Returns the first page in the list of tags
+func (t *TagIterator) First(tagPage *TagsPage) bool {
+	if err := t.cursorRequest(tagPage, t.curr.Paging.First); err != nil {
+		t.err = err
+		return false
+	}
+	t.curr = *tagPage
+	return true
+}
+
+// Returns the last page in the list of tags
+func (t *TagIterator) Last(tagPage *TagsPage) bool {
+	if err := t.cursorRequest(tagPage, t.curr.Paging.Last); err != nil {
+		t.err = err
+		return false
+	}
+	t.curr = *tagPage
+	return true
+}
+
+// Return any error if one occurred
+func (t *TagIterator) Err() error {
+	return t.err
+}
+
+func (t *TagIterator) cursorRequest(tagPage *TagsPage, url string) error {
+	req := newHTTPRequest(url)
+	req.setClient(t.mg.Client())
+	req.setBasicAuth(basicAuthUser, t.mg.ApiKey())
+	return getResponseFromJSON(req, tagPage)
+}
+
+func canFetchPage(slug string) bool {
+	parts, err := url.Parse(slug)
+	if err != nil {
+		return false
+	}
+	params, _ := url.ParseQuery(parts.RawQuery)
+	if err != nil {
+		return false
+	}
+	value, ok := params["tag"]
+	// If tags doesn't exist, it's our first time fetching pages
+	if !ok {
+		return true
+	}
+	// If tags has no value, there are no more pages to fetch
+	return len(value) == 0
+}

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,116 @@
+package mailgun
+
+import (
+	"log"
+
+	"fmt"
+
+	"time"
+
+	"github.com/facebookgo/ensure"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("/v3/{domain}/tags", func() {
+	log := log.New(GinkgoWriter, "tags_test - ", 0)
+	var t GinkgoTInterface
+	var mg Mailgun
+	var err error
+
+	BeforeSuite(func() {
+		mg, err = NewMailgunFromEnv()
+		msg := mg.NewMessage(fromUser, exampleSubject, exampleText, reqEnv(t, "MG_EMAIL_TO"))
+		msg.AddTag("newsletter")
+		msg.AddTag("homer")
+		msg.AddTag("bart")
+		msg.AddTag("disco-steve")
+		msg.AddTag("newsletter")
+		// Create an email with some tags attached
+		_, _, err := mg.Send(msg)
+		if err != nil {
+			Fail(fmt.Sprintf("Mesage send: '%s'", err.Error()))
+		}
+		// Wait for the tag to show up
+		if err := waitForTag(mg, "newsletter"); err != nil {
+			Fail(fmt.Sprintf("While waiting for message: '%s'", err.Error()))
+		}
+	})
+
+	BeforeEach(func() {
+		t = GinkgoT()
+		mg, err = NewMailgunFromEnv()
+		ensure.Nil(t, err)
+	})
+
+	Describe("ListTags()", func() {
+		Context("When a limit parameter of -1 is supplied", func() {
+			It("Should return a list of available tags", func() {
+				it := mg.ListTags(nil)
+				var page TagsPage
+				for it.Next(&page) {
+					Expect(len(page.Items)).NotTo(Equal(0))
+					log.Printf("Tags: %+v\n", page)
+				}
+				ensure.Nil(t, it.Err())
+			})
+		})
+		Context("When limit parameter is supplied", func() {
+			It("Should return a limited list of available tags", func() {
+				cursor := mg.ListTags(&TagOptions{Limit: 1})
+
+				var tags TagsPage
+				for cursor.Next(&tags) {
+					ensure.DeepEqual(t, len(tags.Items), 1)
+					log.Printf("Tags: %+v\n", tags.Items)
+				}
+				ensure.Nil(t, cursor.Err())
+			})
+		})
+	})
+
+	Describe("DeleteTag()", func() {
+		Context("When deleting an existing tag", func() {
+			It("Should not error", func() {
+				err = mg.DeleteTag("newsletter")
+				ensure.Nil(t, err)
+			})
+		})
+	})
+
+	Describe("GetTag()", func() {
+		Context("When requesting an existing tag", func() {
+			It("Should not error", func() {
+				tag, err := mg.GetTag("homer")
+				ensure.Nil(t, err)
+				ensure.DeepEqual(t, tag.Value, "homer")
+			})
+		})
+		Context("When requesting an non-existant tag", func() {
+			It("Should return error", func() {
+				_, err := mg.GetTag("i-dont-exist")
+				ensure.NotNil(t, err)
+				ensure.DeepEqual(t, GetStatusFromErr(err), 404)
+			})
+		})
+	})
+})
+
+func waitForTag(mg Mailgun, tag string) error {
+	var attempts int
+	for attempts <= 5 {
+		_, err := mg.GetTag(tag)
+		if err != nil {
+			if GetStatusFromErr(err) == 404 {
+				time.Sleep(time.Second * 2)
+				attempts += 1
+				continue
+			}
+			return err
+		}
+		return nil
+
+	}
+	return errors.Errorf("Waited to long for tag '%s' to show up", tag)
+}


### PR DESCRIPTION
## Purpose
Add missing tag api calls to `Mailgun` interface and expand CLI capabilities to include fetching and deleting tags.

### API Example
```go
it := mg.ListTags(&TagOptions{Limit: 100})
var page TagsPage
for it.Next(&page) {
	for _, tag := range page.Items {
		// Do stuff with tags
	}
}
if it.Err() != nil {
	log.Fatal(it.Err())
}
```

### CLI 
```bash
$ mailgun tag
Usage:  [OPTIONS]

Manage tags via the mailgun HTTP API

Examples:
   list all available tags
   $ mailgun tag list

   list tags with a specific prefix
   $ mailgun tag list -p foo

   get a single tag
   $ mailgun tag get my-tag

   delete a tag
   $ mailgun tag delete my-tag

Commands:
  list
  get
  delete

Options:
  -v, --verbose      be verbose
  --url              url to the mailgun api
  --api-key          mailgun api key (Env=MG_API_KEY)
  --public-api-key   mailgun public api key (Env=MG_PUBLIC_API_KEY)
  --domain           mailgun api key (Env=MG_DOMAIN)
  -h, --help         Display this help message and exit
```

## Implementation
* Added `mg.ListTags()` to retrieve a list of tags
* Added `mg.GetTag()` to retrieve tag metadata
* Added `mailgun.GetStatusFromErr()` to get the http status code from any error returned by `Mailgun` interface methods
* Moved `mg.DeleteTag()` into `tags.go`
