### PR TITLE
Making the webhook verifier work

### DIFF
--- a/mailgun.go
+++ b/mailgun.go
@@ -196,6 +196,8 @@ type Mailgun interface {
 	NewMessage(from, subject, text string, to ...string) *Message
 	NewMIMEMessage(body io.ReadCloser, to ...string) *Message
 	NewEventIterator() *EventIterator
+	ListEvents(*EventsOptions) *EventIterator
+	PollEvents(*EventsOptions) *EventPoller
 	SetAPIBase(url string)
 }
 
@@ -207,6 +209,7 @@ type MailgunImpl struct {
 	apiKey       string
 	publicApiKey string
 	client       *http.Client
+	baseURL      string
 }
 
 // NewMailGun creates a new client instance.

--- a/mailgun.go
+++ b/mailgun.go
@@ -181,6 +181,7 @@ type Mailgun interface {
 	DeleteWebhook(kind string) error
 	GetWebhookByType(kind string) (string, error)
 	UpdateWebhook(kind, url string) error
+	VerifyWebhookRequest(req *http.Request) (verified bool, err error)
 	GetLists(limit, skip int, filter string) (int, []List, error)
 	CreateList(List) (List, error)
 	DeleteList(string) error
@@ -195,8 +196,6 @@ type Mailgun interface {
 	NewMessage(from, subject, text string, to ...string) *Message
 	NewMIMEMessage(body io.ReadCloser, to ...string) *Message
 	NewEventIterator() *EventIterator
-	ListEvents(*EventsOptions) *EventIterator
-	PollEvents(*EventsOptions) *EventPoller
 	SetAPIBase(url string)
 }
 
@@ -208,7 +207,6 @@ type MailgunImpl struct {
 	apiKey       string
 	publicApiKey string
 	client       *http.Client
-	baseURL      string
 }
 
 // NewMailGun creates a new client instance.


### PR DESCRIPTION
It looks like VerifyWebhookRequest() was unintentionally left out of the Mailgun interface. 