### PR TITLE
VerifyWebhookRequest() doesn't work properly

### DIFF
--- a/webhooks.go
+++ b/webhooks.go
@@ -79,11 +79,11 @@ func (mg *MailgunImpl) UpdateWebhook(t, u string) error {
 
 func (mg *MailgunImpl) VerifyWebhookRequest(req *http.Request) (verified bool, err error) {
 	h := hmac.New(sha256.New, []byte(mg.ApiKey()))
-	io.WriteString(h, req.Form.Get("timestamp"))
-	io.WriteString(h, req.Form.Get("token"))
+	io.WriteString(h, req.FormValue("timestamp"))
+	io.WriteString(h, req.FormValue("token"))
 
 	calculatedSignature := h.Sum(nil)
-	signature, err := hex.DecodeString(req.Form.Get("signature"))
+	signature, err := hex.DecodeString(req.FormValue("signature"))
 	if err != nil {
 		return false, err
 	}

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -1,6 +1,15 @@
 package mailgun
 
 import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/facebookgo/ensure"
@@ -38,4 +47,94 @@ func TestWebhookCRUD(t *testing.T) {
 	ensure.Nil(t, err)
 
 	ensure.DeepEqual(t, hooks["deliver"], "http://api.example.com")
+}
+
+var signedTests = []bool{
+	true,
+	false,
+}
+
+func TestVerifyWebhookRequest_Form(t *testing.T) {
+	mg, err := NewMailgunFromEnv()
+	ensure.Nil(t, err)
+
+	for _, v := range signedTests {
+		fields := getSignatureFields(mg.ApiKey(), v)
+		req := buildFormRequest(fields)
+
+		verified, err := mg.VerifyWebhookRequest(req)
+		ensure.Nil(t, err)
+
+		if v != verified {
+			t.Errorf("VerifyWebhookRequest should return '%v' but get '%v'", v, verified)
+		}
+	}
+}
+
+func TestVerifyWebhookRequest_MultipartForm(t *testing.T) {
+	mg, err := NewMailgunFromEnv()
+	ensure.Nil(t, err)
+
+	for _, v := range signedTests {
+		fields := getSignatureFields(mg.ApiKey(), v)
+		req := buildMultipartFormRequest(fields)
+
+		verified, err := mg.VerifyWebhookRequest(req)
+		ensure.Nil(t, err)
+
+		if v == verified {
+			t.Errorf("VerifyWebhookRequest should return '%v' but get '%v'", v, verified)
+		}
+	}
+}
+
+func buildFormRequest(fields map[string]string) *http.Request {
+	values := url.Values{}
+
+	for k, v := range fields {
+		values.Add(k, v)
+	}
+
+	r := strings.NewReader(values.Encode())
+	req, _ := http.NewRequest("POST", "/", r)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return req
+}
+
+func buildMultipartFormRequest(fields map[string]string) *http.Request {
+	buf := &bytes.Buffer{}
+	writer := multipart.NewWriter(buf)
+
+	for k, v := range fields {
+		writer.WriteField(k, v)
+	}
+
+	writer.Close()
+
+	req, _ := http.NewRequest("POST", "/", buf)
+	req.Header.Set("Content-type", writer.FormDataContentType())
+
+	return req
+}
+
+func getSignatureFields(key string, signed bool) map[string]string {
+	badSignature := hex.EncodeToString([]byte("badsignature"))
+
+	fields := map[string]string{
+		"token": "token",
+		"timestamp": "123456789",
+		"signature": badSignature,
+	}
+
+	if signed {
+		h := hmac.New(sha256.New, []byte(key))
+		io.WriteString(h, fields["timestamp"])
+		io.WriteString(h, fields["token"])
+		hash := h.Sum(nil)
+
+		fields["signature"] = hex.EncodeToString(hash)
+	}
+
+	return fields
 }


### PR DESCRIPTION
The `VerifyWebhookRequest` doesn't work in case of `multipart/form-data` content-type. By using `Request::FormValue()` this will ensure to working in both case.

closes #87 