### PR TITLE
Always runs tests on latest patch release of each minor Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.6
-  - 1.7
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
 
 sudo: true
 


### PR DESCRIPTION
Travis allows you to specify go version in `1.minor.x` or even `1.x` format, which will run tests using the latest patch of release for a minor version or latest minor version of go respectively.

See: https://docs.travis-ci.com/user/languages/go#Specifying-a-Go-version-to-use

Also adds testing on go 1.8, which is due to be released as stable this week. 1.8.x will cause travis to use latest 1.8rc until stable is out.

