### PR TITLE
cli tag command now reports if there was an error

### DIFF
--- a/cmd/mailgun/tag.go
+++ b/cmd/mailgun/tag.go
@@ -95,6 +95,10 @@ func ListTag(parser *args.ArgParser, data interface{}) int {
 			}
 		}
 	}
+	if it.Err() != nil {
+		fmt.Fprint(os.Stderr, it.Err().Error())
+		return 1
+	}
 	return 0
 }
 


### PR DESCRIPTION
## Purpose 
`mailgun tag list` was not reporting errors if they occurred.

## Implementation
Errors are now output to stderr if they occur.