### PR TITLE
Add helper functions for stored messages

### DIFF
--- a/mailgun.go
+++ b/mailgun.go
@@ -161,6 +161,8 @@ type Mailgun interface {
 	GetSingleComplaint(address string) (Complaint, error)
 	GetStoredMessage(id string) (StoredMessage, error)
 	GetStoredMessageRaw(id string) (StoredMessageRaw, error)
+	GetStoredMessageForURL(url string) (StoredMessage, error)
+	GetStoredMessageRawForURL(url string) (StoredMessageRaw, error)
 	DeleteStoredMessage(id string) error
 	GetCredentials(limit, skip int) (int, []Credential, error)
 	CreateCredential(login, password string) error

--- a/messages.go
+++ b/messages.go
@@ -659,6 +659,32 @@ func (mg *MailgunImpl) GetStoredMessageRaw(id string) (StoredMessageRaw, error) 
 	var response StoredMessageRaw
 	err := getResponseFromJSON(r, &response)
 	return response, err
+}
+
+// GetStoredMessageForURL retrieves information about a received e-mail message.
+// This provides visibility into, e.g., replies to a message sent to a mailing list.
+func (mg *MailgunImpl) GetStoredMessageForURL(url string) (StoredMessage, error) {
+	r := newHTTPRequest(url)
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.ApiKey())
+
+	var response StoredMessage
+	err := getResponseFromJSON(r, &response)
+	return response, err
+}
+
+// GetStoredMessageRawForURL retrieves the raw MIME body of a received e-mail message.
+// Compared to GetStoredMessage, it gives access to the unparsed MIME body, and
+// thus delegates to the caller the required parsing.
+func (mg *MailgunImpl) GetStoredMessageRawForURL(url string) (StoredMessageRaw, error) {
+	r := newHTTPRequest(url)
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.ApiKey())
+	r.addHeader("Accept", "message/rfc2822")
+
+	var response StoredMessageRaw
+	err := getResponseFromJSON(r, &response)
+	return response, err
 
 }
 


### PR DESCRIPTION
I added these functions for two reasons:

1. Recently when I am notified of new stored messages the `message-url` begins `https://se.api.mailgun.net/v3/domains/mydomain.com/messages/` instead of `https://api.mailgun.net/v3/domains/mydomain.com/messages/`. So I was having to check the URL to see if it was `se.api` or just `api` and change the Base API URL for the entire client if so.

2. The message ID required by `GetStoredMessage` can only be extracted from the `message-url` itself.