### PR TITLE
A couple unmarshalling fixes

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -222,6 +222,7 @@ const (
 	ClientBrowser
 	ClientEmail
 	ClientLibrary
+	ClientRobot
 )
 
 var clientTypes = []string{
@@ -230,6 +231,7 @@ var clientTypes = []string{
 	"browser",
 	"email client",
 	"library",
+	"robot",
 }
 
 func (ct ClientType) String() string {

--- a/enums.go
+++ b/enums.go
@@ -223,6 +223,7 @@ const (
 	ClientEmail
 	ClientLibrary
 	ClientRobot
+	ClientOther
 )
 
 var clientTypes = []string{
@@ -232,6 +233,7 @@ var clientTypes = []string{
 	"email client",
 	"library",
 	"robot",
+	"other",
 }
 
 func (ct ClientType) String() string {

--- a/enums.go
+++ b/enums.go
@@ -256,17 +256,19 @@ func (ct *ClientType) UnmarshalText(text []byte) error {
 type DeviceType uint
 
 const (
-	DeviceOther DeviceType = iota
+	DeviceUnknown DeviceType = iota
 	DeviceMobileBrowser
 	DeviceBrowser
 	DeviceEmail
+	DeviceOther
 )
 
 var deviceTypes = []string{
-	"other",
+	"unknown",
 	"desktop",
 	"mobile",
 	"tablet",
+	"other",
 }
 
 func (ct DeviceType) String() string {

--- a/enums.go
+++ b/enums.go
@@ -256,14 +256,14 @@ func (ct *ClientType) UnmarshalText(text []byte) error {
 type DeviceType uint
 
 const (
-	DeviceUnknown DeviceType = iota
+	DeviceOther DeviceType = iota
 	DeviceMobileBrowser
 	DeviceBrowser
 	DeviceEmail
 )
 
 var deviceTypes = []string{
-	"unknown",
+	"other",
 	"desktop",
 	"mobile",
 	"tablet",

--- a/enums.go
+++ b/enums.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -86,7 +87,8 @@ func (i IP) MarshalText() ([]byte, error) {
 
 // UnmarshalText satisfies TextUnmarshaler
 func (i *IP) UnmarshalText(text []byte) error {
-	v := net.ParseIP(string(text))
+	s := strings.Trim(string(text), "\"")
+	v := net.ParseIP(s)
 	if v != nil {
 		*i = IP(v)
 	}

--- a/enums.go
+++ b/enums.go
@@ -141,8 +141,8 @@ const (
 
 var severities = []string{
 	"unknown",
-	"permanent",
 	"temporary",
+	"permanent",
 	"internal",
 }
 

--- a/events.go
+++ b/events.go
@@ -51,10 +51,10 @@ type Event struct {
 }
 
 type DeliveryStatus struct {
-	Message     *string `json:"message,omitempty"`
-	Code        *int    `json:"code,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Retry       *int    `json:"retry-seconds,omitempty"`
+	Message     *string     `json:"message,omitempty"`
+	Code        interface{} `json:"code,omitempty"`
+	Description *string     `json:"description,omitempty"`
+	Retry       *int        `json:"retry-seconds,omitempty"`
 }
 
 type EventFlags struct {


### PR DESCRIPTION
Stuff we fixed when production data made our code explode.

Fixes:

- `delivery-status.code` is sometimes sent as a number, sometimes a string (quoted number)
- fix IP unmarshalling
- fix severity string representation not matching enum
- add two more client types - `robot` and `other` - that we've encountered in in production data

Questions:
1. why does Mailgun have both `other` and `unknown` client types? whats the difference?
2. can you decide if code is int or string