### PR TITLE
fix segfault in CreateRoute

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -59,7 +59,7 @@ func (mg *MailgunImpl) GetRoutes(limit, skip int) (int, []Route, error) {
 // The route structure you provide serves as a template, and
 // only a subset of the fields influence the operation.
 // See the Route structure definition for more details.
-func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
+func (mg *MailgunImpl) CreateRoute(prototype Route) (_ignored Route, err error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, routesEndpoint))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.ApiKey())
@@ -74,7 +74,11 @@ func (mg *MailgunImpl) CreateRoute(prototype Route) (Route, error) {
 		Message string `json:"message"`
 		*Route  `json:"route"`
 	}
-	err := postResponseFromJSON(r, p, &envelope)
+	if err = postResponseFromJSON(r, p, &envelope); err != nil {
+		return _ignored, err
+	}
+
+	err = postResponseFromJSON(r, p, &envelope)
 	return *envelope.Route, err
 }
 


### PR DESCRIPTION
don't deference a potentially nil value.

happens when mailgun returns an error.