### PR TITLE
Add greylisted and blacklisted reasons

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -174,6 +174,8 @@ const (
 	ReasonGeneric
 	ReasonBounce
 	ReasonESPBlock
+	ReasonGreylisted
+	ReasonBlacklisted
 	ReasonSuppressBounce
 	ReasonSuppressComplaint
 	ReasonSuppressUnsubscribe
@@ -186,6 +188,8 @@ var eventReasons = []string{
 	"generic",
 	"bounce",
 	"espblock",
+	"greylisted",
+	"blacklisted",
 	"suppress-bounce",
 	"suppress-complaint",
 	"suppress-unsubscribe",


### PR DESCRIPTION
We broke out the `greylisted` and `blacklisted` reasons for failed messages from the more generic `espblock`. `greylisted` messages are those that we need to retry later from the same IP address. `blacklisted` messages are those that failed due to a blacklist entry that we indent to take some action on so that the message may become deliverable at a later date and should be retried. This PR adds those 2 new reasons to the enumerated list.