### PR TITLE
Change example to use non-deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ package main
 import "gopkg.in/mailgun/mailgun-go.v1"
 
 mg := mailgun.NewMailgun(yourdomain, ApiKey, publicApiKey)
-message := mailgun.NewMessage(
+message := mg.NewMessage(
     "sender@example.com",
     "Fancy subject!",
     "Hello from Mailgun Go!",


### PR DESCRIPTION
The example initializes mg as a new MailgunImpl instance. The call to NewMessage
should use the mg.NewMessage method and not the static mailgun.NewMessage
function, because it's deprecated.