### PR TITLE
Added missing base URL to instantiation by environment variables.

### DIFF
--- a/mailgun.go
+++ b/mailgun.go
@@ -243,6 +243,7 @@ func NewMailgunFromEnv() (Mailgun, error) {
 	}
 
 	mg := MailgunImpl{
+		apiBase:      ApiBase,
 		domain:       domain,
 		apiKey:       apiKey,
 		publicApiKey: os.Getenv("MG_PUBLIC_API_KEY"),


### PR DESCRIPTION
Creation of `MailgunImpl` using environment variables is missing a base URL.