### PR TITLE
Fixed MailboxVerification parsing error

### DIFF
--- a/email_validation.go
+++ b/email_validation.go
@@ -36,7 +36,7 @@ type EmailVerificationParts struct {
 // Reason contains error's description.
 type EmailVerification struct {
 	IsValid             bool                   `json:"is_valid"`
-	MailboxVerification bool                   `json:"mailbox_verification,string"`
+	MailboxVerification string                 `json:"mailbox_verification"`
 	Parts               EmailVerificationParts `json:"parts"`
 	Address             string                 `json:"address"`
 	DidYouMean          string                 `json:"did_you_mean"`


### PR DESCRIPTION
This should fix #140 Documentation states this is a `string` as it *could* include the string `unknown` if we can't figure out if the ESP knows about the mbox.