### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/bounces.go
+++ b/bounces.go
@@ -62,7 +62,7 @@ func (ci *BouncesIterator) Err() error {
 	return ci.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ci *BouncesIterator) Next(ctx context.Context, items *[]Bounce) bool {
@@ -82,7 +82,7 @@ func (ci *BouncesIterator) Next(ctx context.Context, items *[]Bounce) bool {
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ci *BouncesIterator) First(ctx context.Context, items *[]Bounce) bool {
@@ -99,7 +99,7 @@ func (ci *BouncesIterator) First(ctx context.Context, items *[]Bounce) bool {
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -117,7 +117,7 @@ func (ci *BouncesIterator) Last(ctx context.Context, items *[]Bounce) bool {
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ci *BouncesIterator) Previous(ctx context.Context, items *[]Bounce) bool {

--- a/credentials.go
+++ b/credentials.go
@@ -55,12 +55,12 @@ func (ri *CredentialsIterator) Err() error {
 	return ri.err
 }
 
-// Returns the current offset of the iterator
+// Offset returns the current offset of the iterator
 func (ri *CredentialsIterator) Offset() int {
 	return ri.offset
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ri *CredentialsIterator) Next(ctx context.Context, items *[]Credential) bool {
@@ -83,7 +83,7 @@ func (ri *CredentialsIterator) Next(ctx context.Context, items *[]Credential) bo
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ri *CredentialsIterator) First(ctx context.Context, items *[]Credential) bool {
@@ -101,7 +101,7 @@ func (ri *CredentialsIterator) First(ctx context.Context, items *[]Credential) b
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -129,7 +129,7 @@ func (ri *CredentialsIterator) Last(ctx context.Context, items *[]Credential) bo
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ri *CredentialsIterator) Previous(ctx context.Context, items *[]Credential) bool {

--- a/domains.go
+++ b/domains.go
@@ -112,12 +112,12 @@ func (ri *DomainsIterator) Err() error {
 	return ri.err
 }
 
-// Returns the current offset of the iterator
+// Offset returns the current offset of the iterator
 func (ri *DomainsIterator) Offset() int {
 	return ri.offset
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ri *DomainsIterator) Next(ctx context.Context, items *[]Domain) bool {
@@ -140,7 +140,7 @@ func (ri *DomainsIterator) Next(ctx context.Context, items *[]Domain) bool {
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ri *DomainsIterator) First(ctx context.Context, items *[]Domain) bool {
@@ -158,7 +158,7 @@ func (ri *DomainsIterator) First(ctx context.Context, items *[]Domain) bool {
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -186,7 +186,7 @@ func (ri *DomainsIterator) Last(ctx context.Context, items *[]Domain) bool {
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ri *DomainsIterator) Previous(ctx context.Context, items *[]Domain) bool {
@@ -231,7 +231,7 @@ func (ri *DomainsIterator) fetch(ctx context.Context, skip, limit int) error {
 	return getResponseFromJSON(ctx, r, &ri.domainsListResponse)
 }
 
-// Retrieve detailed information about the named domain.
+// GetDomain retrieves detailed information about the named domain.
 func (mg *MailgunImpl) GetDomain(ctx context.Context, domain string) (DomainResponse, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain)
 	r.setClient(mg.Client())
@@ -298,7 +298,7 @@ func (mg *MailgunImpl) CreateDomain(ctx context.Context, name string, password s
 	return resp, err
 }
 
-// Returns delivery connection settings for the defined domain
+// GetDomainConnection returns delivery connection settings for the defined domain
 func (mg *MailgunImpl) GetDomainConnection(ctx context.Context, domain string) (DomainConnection, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/connection")
 	r.setClient(mg.Client())
@@ -330,7 +330,7 @@ func (mg *MailgunImpl) DeleteDomain(ctx context.Context, name string) error {
 	return err
 }
 
-// Returns tracking settings for a domain
+// GetDomainTracking returns tracking settings for a domain
 func (mg *MailgunImpl) GetDomainTracking(ctx context.Context, domain string) (DomainTracking, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/tracking")
 	r.setClient(mg.Client())

--- a/email_validation.go
+++ b/email_validation.go
@@ -81,7 +81,7 @@ func NewEmailValidator(apiKey string) *EmailValidatorImpl {
 	}
 }
 
-// Return a new EmailValidator using environment variables
+// NewEmailValidatorFromEnv returns a new EmailValidator using environment variables
 // If MG_PUBLIC_API_KEY is set, assume using the free validation subject to daily usage limits
 // If only MG_API_KEY is set, assume using the /private validation routes with no daily usage limits
 func NewEmailValidatorFromEnv() (*EmailValidatorImpl, error) {
@@ -121,7 +121,7 @@ func (m *EmailValidatorImpl) Client() *http.Client {
 	return m.client
 }
 
-// Returns the API key used for validations
+// APIKey returns the API key used for validations
 func (m *EmailValidatorImpl) APIKey() string {
 	return m.apiKey
 }

--- a/events.go
+++ b/events.go
@@ -75,7 +75,7 @@ func (ei *EventIterator) Err() error {
 	return ei.err
 }
 
-// Retrieves the next page of events from the api. Returns false when there
+// Next retrieves the next page of events from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ei *EventIterator) Next(ctx context.Context, events *[]Event) bool {
@@ -93,7 +93,7 @@ func (ei *EventIterator) Next(ctx context.Context, events *[]Event) bool {
 	return true
 }
 
-// Retrieves the first page of events from the api. Returns false if there
+// First retrieves the first page of events from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ei *EventIterator) First(ctx context.Context, events *[]Event) bool {
@@ -108,7 +108,7 @@ func (ei *EventIterator) First(ctx context.Context, events *[]Event) bool {
 	return true
 }
 
-// Retrieves the last page of events from the api.
+// Last retrieves the last page of events from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -124,7 +124,7 @@ func (ei *EventIterator) Last(ctx context.Context, events *[]Event) bool {
 	return true
 }
 
-// Retrieves the previous page of events from the api. Returns false when there
+// Previous retrieves the previous page of events from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ei *EventIterator) Previous(ctx context.Context, events *[]Event) bool {

--- a/exports.go
+++ b/exports.go
@@ -50,7 +50,7 @@ func (mg *MailgunImpl) ListExports(ctx context.Context, url string) ([]Export, e
 	return result, nil
 }
 
-// Get an export by id
+// GetExport gets an export by id
 func (mg *MailgunImpl) GetExport(ctx context.Context, id string) (Export, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, exportsEndpoint) + "/" + id)
 	r.setClient(mg.Client())

--- a/ips.go
+++ b/ips.go
@@ -18,7 +18,7 @@ type okResp struct {
 	Message string `json:"message"`
 }
 
-// Returns a list of IPs assigned to your account
+// ListIPS returns a list of IPs assigned to your account
 func (mg *MailgunImpl) ListIPS(ctx context.Context, dedicated bool) ([]IPAddress, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, ipsEndpoint))
 	r.setClient(mg.Client())
@@ -38,7 +38,7 @@ func (mg *MailgunImpl) ListIPS(ctx context.Context, dedicated bool) ([]IPAddress
 	return result, nil
 }
 
-// Returns information about the specified IP
+// GetIP returns information about the specified IP
 func (mg *MailgunImpl) GetIP(ctx context.Context, ip string) (IPAddress, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, ipsEndpoint) + "/" + ip)
 	r.setClient(mg.Client())
@@ -48,7 +48,7 @@ func (mg *MailgunImpl) GetIP(ctx context.Context, ip string) (IPAddress, error) 
 	return resp, err
 }
 
-// Returns a list of IPs currently assigned to the specified domain.
+// ListDomainIPS returns a list of IPs currently assigned to the specified domain.
 func (mg *MailgunImpl) ListDomainIPS(ctx context.Context) ([]IPAddress, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + mg.domain + "/ips")
 	r.setClient(mg.Client())

--- a/limits.go
+++ b/limits.go
@@ -7,7 +7,7 @@ type TagLimits struct {
 	Count int `json:"count"`
 }
 
-// Returns tracking settings for a domain
+// GetTagLimits returns tracking settings for a domain
 func (mg *MailgunImpl) GetTagLimits(ctx context.Context, domain string) (TagLimits, error) {
 	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/limits/tag")
 	r.setClient(mg.Client())

--- a/mailgun.go
+++ b/mailgun.go
@@ -248,7 +248,7 @@ func NewMailgun(domain, apiKey string) *MailgunImpl {
 	}
 }
 
-// Return a new Mailgun client using the environment variables
+// NewMailgunFromEnv returns a new Mailgun client using the environment variables
 // MG_API_KEY, MG_DOMAIN, and MG_URL
 func NewMailgunFromEnv() (*MailgunImpl, error) {
 	apiKey := os.Getenv("MG_API_KEY")

--- a/mailing_lists.go
+++ b/mailing_lists.go
@@ -72,7 +72,7 @@ func (li *ListsIterator) Err() error {
 	return li.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (li *ListsIterator) Next(ctx context.Context, items *[]MailingList) bool {
@@ -92,7 +92,7 @@ func (li *ListsIterator) Next(ctx context.Context, items *[]MailingList) bool {
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (li *ListsIterator) First(ctx context.Context, items *[]MailingList) bool {
@@ -109,7 +109,7 @@ func (li *ListsIterator) First(ctx context.Context, items *[]MailingList) bool {
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -127,7 +127,7 @@ func (li *ListsIterator) Last(ctx context.Context, items *[]MailingList) bool {
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (li *ListsIterator) Previous(ctx context.Context, items *[]MailingList) bool {
@@ -215,7 +215,7 @@ func (mg *MailgunImpl) GetMailingList(ctx context.Context, addr string) (Mailing
 	return resp.MailingList, err
 }
 
-// UpdateList allows you to change various attributes of a list.
+// UpdateMailingList allows you to change various attributes of a list.
 // Address, Name, Description, and AccessLevel are all optional;
 // only those fields which are set in the prototype will change.
 //

--- a/members.go
+++ b/members.go
@@ -77,7 +77,7 @@ func (li *MemberListIterator) Err() error {
 	return li.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (li *MemberListIterator) Next(ctx context.Context, items *[]Member) bool {
@@ -95,7 +95,7 @@ func (li *MemberListIterator) Next(ctx context.Context, items *[]Member) bool {
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (li *MemberListIterator) First(ctx context.Context, items *[]Member) bool {
@@ -110,7 +110,7 @@ func (li *MemberListIterator) First(ctx context.Context, items *[]Member) bool {
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -126,7 +126,7 @@ func (li *MemberListIterator) Last(ctx context.Context, items *[]Member) bool {
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (li *MemberListIterator) Previous(ctx context.Context, items *[]Member) bool {

--- a/messages.go
+++ b/messages.go
@@ -444,7 +444,7 @@ func (m *Message) AddDomain(domain string) {
 	m.domain = domain
 }
 
-// Retrieve the http headers associated with this message
+// GetHeaders retrieves the http headers associated with this message
 func (m *Message) GetHeaders() map[string]string {
 	return m.headers
 }
@@ -747,7 +747,7 @@ func (mg *MailgunImpl) GetStoredMessageRawForURL(ctx context.Context, url string
 	return mg.GetStoredMessageRaw(ctx, url)
 }
 
-// Retrieves the raw MIME body of a received e-mail message attachment.
+// GetStoredAttachment retrieves the raw MIME body of a received e-mail message attachment.
 func (mg *MailgunImpl) GetStoredAttachment(ctx context.Context, url string) ([]byte, error) {
 	r := newHTTPRequest(url)
 	r.setClient(mg.Client())

--- a/mock.go
+++ b/mock.go
@@ -54,7 +54,7 @@ func (ms *MockServer) Stop() {
 	ms.srv.Close()
 }
 
-// Return the URL used to connect to the mock server
+// URL returns the URL used to connect to the mock server
 func (ms *MockServer) URL() string {
 	return ms.srv.URL + "/v3"
 }

--- a/routes.go
+++ b/routes.go
@@ -73,12 +73,12 @@ func (ri *RoutesIterator) Err() error {
 	return ri.err
 }
 
-// Returns the current offset of the iterator
+// Offset returns the current offset of the iterator
 func (ri *RoutesIterator) Offset() int {
 	return ri.offset
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ri *RoutesIterator) Next(ctx context.Context, items *[]Route) bool {
@@ -101,7 +101,7 @@ func (ri *RoutesIterator) Next(ctx context.Context, items *[]Route) bool {
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ri *RoutesIterator) First(ctx context.Context, items *[]Route) bool {
@@ -119,7 +119,7 @@ func (ri *RoutesIterator) First(ctx context.Context, items *[]Route) bool {
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -147,7 +147,7 @@ func (ri *RoutesIterator) Last(ctx context.Context, items *[]Route) bool {
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ri *RoutesIterator) Previous(ctx context.Context, items *[]Route) bool {

--- a/spam_complaints.go
+++ b/spam_complaints.go
@@ -53,7 +53,7 @@ func (ci *ComplaintsIterator) Err() error {
 	return ci.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ci *ComplaintsIterator) Next(ctx context.Context, items *[]Complaint) bool {
@@ -73,7 +73,7 @@ func (ci *ComplaintsIterator) Next(ctx context.Context, items *[]Complaint) bool
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ci *ComplaintsIterator) First(ctx context.Context, items *[]Complaint) bool {
@@ -90,7 +90,7 @@ func (ci *ComplaintsIterator) First(ctx context.Context, items *[]Complaint) boo
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -108,7 +108,7 @@ func (ci *ComplaintsIterator) Last(ctx context.Context, items *[]Complaint) bool
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ci *ComplaintsIterator) Previous(ctx context.Context, items *[]Complaint) bool {

--- a/stats.go
+++ b/stats.go
@@ -85,7 +85,7 @@ type GetStatOptions struct {
 	End        time.Time
 }
 
-// Returns total stats for a given domain for the specified time period
+// GetStats returns total stats for a given domain for the specified time period
 func (mg *MailgunImpl) GetStats(ctx context.Context, events []string, opts *GetStatOptions) ([]Stats, error) {
 	r := newHTTPRequest(generateApiUrl(mg, statsTotalEndpoint))
 

--- a/tags.go
+++ b/tags.go
@@ -80,7 +80,7 @@ type TagIterator struct {
 	err error
 }
 
-// Returns the next page in the list of tags
+// Next returns the next page in the list of tags
 func (ti *TagIterator) Next(ctx context.Context, items *[]Tag) bool {
 	if ti.err != nil {
 		return false
@@ -101,7 +101,7 @@ func (ti *TagIterator) Next(ctx context.Context, items *[]Tag) bool {
 	return true
 }
 
-// Returns the previous page in the list of tags
+// Previous returns the previous page in the list of tags
 func (ti *TagIterator) Previous(ctx context.Context, items *[]Tag) bool {
 	if ti.err != nil {
 		return false
@@ -126,7 +126,7 @@ func (ti *TagIterator) Previous(ctx context.Context, items *[]Tag) bool {
 	return true
 }
 
-// Returns the first page in the list of tags
+// First returns the first page in the list of tags
 func (ti *TagIterator) First(ctx context.Context, items *[]Tag) bool {
 	if ti.err != nil {
 		return false
@@ -139,7 +139,7 @@ func (ti *TagIterator) First(ctx context.Context, items *[]Tag) bool {
 	return true
 }
 
-// Returns the last page in the list of tags
+// Last returns the last page in the list of tags
 func (ti *TagIterator) Last(ctx context.Context, items *[]Tag) bool {
 	if ti.err != nil {
 		return false
@@ -152,7 +152,7 @@ func (ti *TagIterator) Last(ctx context.Context, items *[]Tag) bool {
 	return true
 }
 
-// Return any error if one occurred
+// Err returns any error if one occurred
 func (ti *TagIterator) Err() error {
 	return ti.err
 }

--- a/template.go
+++ b/template.go
@@ -65,7 +65,7 @@ func (mg *MailgunImpl) CreateTemplate(ctx context.Context, template *Template) e
 	return nil
 }
 
-// Get a template given the template name
+// GetTemplate gets a template given the template name
 func (mg *MailgunImpl) GetTemplate(ctx context.Context, name string) (Template, error) {
 	r := newHTTPRequest(generateApiUrl(mg, templatesEndpoint) + "/" + name)
 	r.setClient(mg.Client())
@@ -145,7 +145,7 @@ func (ti *TemplatesIterator) Err() error {
 	return ti.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ti *TemplatesIterator) Next(ctx context.Context, items *[]Template) bool {
@@ -165,7 +165,7 @@ func (ti *TemplatesIterator) Next(ctx context.Context, items *[]Template) bool {
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ti *TemplatesIterator) First(ctx context.Context, items *[]Template) bool {
@@ -182,7 +182,7 @@ func (ti *TemplatesIterator) First(ctx context.Context, items *[]Template) bool 
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -200,7 +200,7 @@ func (ti *TemplatesIterator) Last(ctx context.Context, items *[]Template) bool {
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ti *TemplatesIterator) Previous(ctx context.Context, items *[]Template) bool {

--- a/template_versions.go
+++ b/template_versions.go
@@ -22,7 +22,7 @@ type templateVersionListResp struct {
 	Paging Paging `json:"paging"`
 }
 
-// Add a template version to a template
+// AddTemplateVersion adds a template version to a template
 func (mg *MailgunImpl) AddTemplateVersion(ctx context.Context, templateName string, version *TemplateVersion) error {
 	r := newHTTPRequest(generateApiUrl(mg, templatesEndpoint) + "/" + templateName + "/versions")
 	r.setClient(mg.Client())
@@ -52,7 +52,7 @@ func (mg *MailgunImpl) AddTemplateVersion(ctx context.Context, templateName stri
 	return nil
 }
 
-// Get a specific version of a template
+// GetTemplateVersion gets a specific version of a template
 func (mg *MailgunImpl) GetTemplateVersion(ctx context.Context, templateName, tag string) (TemplateVersion, error) {
 	r := newHTTPRequest(generateApiUrl(mg, templatesEndpoint) + "/" + templateName + "/versions/" + tag)
 	r.setClient(mg.Client())
@@ -127,7 +127,7 @@ func (li *TemplateVersionsIterator) Err() error {
 	return li.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (li *TemplateVersionsIterator) Next(ctx context.Context, items *[]TemplateVersion) bool {
@@ -147,7 +147,7 @@ func (li *TemplateVersionsIterator) Next(ctx context.Context, items *[]TemplateV
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (li *TemplateVersionsIterator) First(ctx context.Context, items *[]TemplateVersion) bool {
@@ -164,7 +164,7 @@ func (li *TemplateVersionsIterator) First(ctx context.Context, items *[]Template
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -182,7 +182,7 @@ func (li *TemplateVersionsIterator) Last(ctx context.Context, items *[]TemplateV
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (li *TemplateVersionsIterator) Previous(ctx context.Context, items *[]TemplateVersion) bool {

--- a/unsubscribes.go
+++ b/unsubscribes.go
@@ -46,7 +46,7 @@ func (ci *UnsubscribesIterator) Err() error {
 	return ci.err
 }
 
-// Retrieves the next page of items from the api. Returns false when there
+// Next retrieves the next page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error
 func (ci *UnsubscribesIterator) Next(ctx context.Context, items *[]Unsubscribe) bool {
@@ -66,7 +66,7 @@ func (ci *UnsubscribesIterator) Next(ctx context.Context, items *[]Unsubscribe) 
 	return true
 }
 
-// Retrieves the first page of items from the api. Returns false if there
+// First retrieves the first page of items from the api. Returns false if there
 // was an error. It also sets the iterator object to the first page.
 // Use `.Err()` to retrieve the error.
 func (ci *UnsubscribesIterator) First(ctx context.Context, items *[]Unsubscribe) bool {
@@ -83,7 +83,7 @@ func (ci *UnsubscribesIterator) First(ctx context.Context, items *[]Unsubscribe)
 	return true
 }
 
-// Retrieves the last page of items from the api.
+// Last retrieves the last page of items from the api.
 // Calling Last() is invalid unless you first call First() or Next()
 // Returns false if there was an error. It also sets the iterator object
 // to the last page. Use `.Err()` to retrieve the error.
@@ -101,7 +101,7 @@ func (ci *UnsubscribesIterator) Last(ctx context.Context, items *[]Unsubscribe) 
 	return true
 }
 
-// Retrieves the previous page of items from the api. Returns false when there
+// Previous retrieves the previous page of items from the api. Returns false when there
 // no more pages to retrieve or if there was an error. Use `.Err()` to retrieve
 // the error if any
 func (ci *UnsubscribesIterator) Previous(ctx context.Context, items *[]Unsubscribe) bool {
@@ -157,7 +157,7 @@ func (mg *MailgunImpl) CreateUnsubscribe(ctx context.Context, address, tag strin
 	return err
 }
 
-// Removes the e-mail address given from the domain's unsubscription table.
+// DeleteUnsubscribe removes the e-mail address given from the domain's unsubscription table.
 // If passing in an ID (discoverable from, e.g., ListUnsubscribes()), the e-mail address associated
 // with the given ID will be removed.
 func (mg *MailgunImpl) DeleteUnsubscribe(ctx context.Context, address string) error {
@@ -168,7 +168,7 @@ func (mg *MailgunImpl) DeleteUnsubscribe(ctx context.Context, address string) er
 	return err
 }
 
-// Removes the e-mail address given from the domain's unsubscription table with a matching tag.
+// DeleteUnsubscribeWithTag removes the e-mail address given from the domain's unsubscription table with a matching tag.
 // If passing in an ID (discoverable from, e.g., ListUnsubscribes()), the e-mail address associated
 // with the given ID will be removed.
 func (mg *MailgunImpl) DeleteUnsubscribeWithTag(ctx context.Context, a, t string) error {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?