### PR TITLE
Check for parsing errors

### DIFF
--- a/events.go
+++ b/events.go
@@ -87,6 +87,9 @@ func (ei *EventIterator) Next(ctx context.Context, events *[]Event) bool {
 		return false
 	}
 	*events, ei.err = ParseEvents(ei.Items)
+	if ei.err != nil {
+		return false
+	}
 	if len(ei.Items) == 0 {
 		return false
 	}


### PR DESCRIPTION
We noticed a large number of errors today as a result of an unchecked error when iterator over events.

1. this PR prevents the iterator from returning `true` if there was a parsing error.

2. are you aware of any changes introduced today ~`Apr 16, 2019 1:34:49 PM EDT`, such as a new JSON event type returned by /events API ?

3. is there a mailing list one can subscribe to when new features are introduced to the API?