### PR TITLE
changed user variables to take an interface and send entire JSON object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 )
 
 replace github.com/mailgun/mailgun-go/v3/events => ./events
+
+go 1.13

--- a/messages.go
+++ b/messages.go
@@ -571,9 +571,6 @@ func (mg *MailgunImpl) Send(ctx context.Context, message *Message) (mes string, 
 		message.domain = mg.Domain()
 	}
 
-	// fmt.Printf("\n-----------------------------\n%+v\n----------------------%+v\n-------------------------\n", payload, message)
-	// return
-
 	r := newHTTPRequest(generateApiUrlWithDomain(mg, message.specific.endpoint(), message.domain))
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.APIKey())

--- a/messages_test.go
+++ b/messages_test.go
@@ -286,12 +286,14 @@ func TestSendMGMessageVariables(t *testing.T) {
 		exampleStrVarKey    = "test-str-key"
 		exampleStrVarVal    = "test-str-val"
 		exampleBoolVarKey   = "test-bool-key"
-		exampleBoolVarVal   = "false"
+		exampleBoolVarVal   = false
 		exampleMapVarKey    = "test-map-key"
 		exampleMapVarStrVal = `{"test":"123"}`
 	)
 	var (
-		exampleMapVarVal = map[string]string{"test": "123"}
+		exampleMapVarVal              = map[string]string{"test": "123"}
+		exampleExpectedVariableHeader = fmt.Sprintf(`{"%s":%v,"%s":%s,"%s":"%s"}`,
+			exampleBoolVarKey, exampleBoolVarVal, exampleMapVarKey, exampleMapVarStrVal, exampleStrVarKey, exampleStrVarVal)
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ensure.DeepEqual(t, req.Method, http.MethodPost)
@@ -301,9 +303,7 @@ func TestSendMGMessageVariables(t *testing.T) {
 		ensure.DeepEqual(t, req.FormValue("subject"), exampleSubject)
 		ensure.DeepEqual(t, req.FormValue("text"), exampleText)
 		ensure.DeepEqual(t, req.FormValue("to"), toUser)
-		ensure.DeepEqual(t, req.FormValue("v:"+exampleMapVarKey), exampleMapVarStrVal)
-		ensure.DeepEqual(t, req.FormValue("v:"+exampleBoolVarKey), exampleBoolVarVal)
-		ensure.DeepEqual(t, req.FormValue("v:"+exampleStrVarKey), exampleStrVarVal)
+		ensure.DeepEqual(t, req.FormValue("h:X-Mailgun-Variables"), exampleExpectedVariableHeader)
 		rsp := fmt.Sprintf(`{"message":"%s", "id":"%s"}`, exampleMessage, exampleID)
 		fmt.Fprint(w, rsp)
 	}))


### PR DESCRIPTION
I took a quick stab at addressing issue #200 by changing the message.variables field to be a map[string]interface{} then JSON marshalling the map at send time into the X-Mailgun-Variables header. If the marshal fails, it falls back to the v: headers. 

Let me know if I missed anything obvious or if there was a better place to do this. In my testing, it sent the variables up correctly and the handlebars template was able to iterate over the values correctly.