### PR TITLE
Stats: fix time format

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -2,10 +2,9 @@ package mailgun
 
 import (
 	"context"
+	"strconv"
 	"time"
 )
-
-const iso8601date = "2006-01-02"
 
 // Stats on accepted messages
 type Accepted struct {
@@ -91,10 +90,10 @@ func (mg *MailgunImpl) GetStats(ctx context.Context, events []string, opts *GetS
 
 	if opts != nil {
 		if !opts.Start.IsZero() {
-			r.addParameter("start", opts.Start.Format(iso8601date))
+			r.addParameter("start", strconv.Itoa(int(opts.Start.Unix())))
 		}
 		if !opts.End.IsZero() {
-			r.addParameter("end", opts.End.Format(iso8601date))
+			r.addParameter("end", strconv.Itoa(int(opts.End.Unix())))
 		}
 		if opts.Resolution != "" {
 			r.addParameter("resolution", string(opts.Resolution))


### PR DESCRIPTION
I have an error with stats requests  (again:)) 

```
UnexpectedResponseError URL=https://api.eu.mailgun.net/v3/mg.one.tools/stats/total ExpectedOneOf=[]int{200, 202, 204} Got=400 Error: {"message":"failed to parse 'end', valid format is RFC 2822 or epoch time
```
RFC 2822 format `"Mon Jan 02 15:04:05 -0700 2006` is also not parsed    
