### PR TITLE
Add missing context in EmailValidator interface

### DIFF
--- a/email_validation.go
+++ b/email_validation.go
@@ -51,8 +51,8 @@ type addressParseResult struct {
 }
 
 type EmailValidator interface {
-	ValidateEmail(email string, mailBoxVerify bool) (EmailVerification, error)
-	ParseAddresses(addresses ...string) ([]string, []string, error)
+	ValidateEmail(ctx context.Context, email string, mailBoxVerify bool) (EmailVerification, error)
+	ParseAddresses(ctx context.Context, addresses ...string) ([]string, []string, error)
 }
 
 type EmailValidatorImpl struct {


### PR DESCRIPTION
EmailValidatorImpl doesn't match the interface and I can't mock it :)