### PR TITLE
Bumped major version to v4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2020-01-27
+### Changes
+* Changed `UserVariables` type from `map[string]interface{}` to `interface{}`
+  to handle truncated user-variable messages in events.
+### Added
+* Add support for setting AMP content in messages
+
 ## [3.6.3] - 2019-12-03
 ### Changes
 * Calls to get stats now use epoch as the time format

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 
 Go library for interacting with the [Mailgun](https://mailgun.com/) [API](https://documentation.mailgun.com/api_reference.html).
 
-**NOTE: Backward compatibility has been broken with the v3.0 release which includes versioned paths required by 1.11 
-go modules (See [Releasing Modules](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher)).
- Pin your dependencies to the v1.1.1 or v2.0 tag if you are not ready for v3.0**
-
 ## Usage
 ```go
 package main
@@ -19,7 +15,7 @@ import (
     "log"
     "time"
 
-    "github.com/mailgun/mailgun-go/v3"
+    "github.com/mailgun/mailgun-go/v4"
 )
 
 // Your available domain names can be found here:
@@ -66,8 +62,8 @@ import (
     "fmt"
     "time"
 
-    "github.com/mailgun/mailgun-go/v3"
-    "github.com/mailgun/mailgun-go/v3/events"
+    "github.com/mailgun/mailgun-go/v4"
+    "github.com/mailgun/mailgun-go/v4/events"
 )
 
 func main() {
@@ -122,7 +118,7 @@ import (
     "context"
     "time"
 
-    "github.com/mailgun/mailgun-go/v3"
+    "github.com/mailgun/mailgun-go/v4"
 )
 
 func main() {
@@ -163,7 +159,7 @@ import (
     "log"
     "time"
 
-    "github.com/mailgun/mailgun-go/v3"
+    "github.com/mailgun/mailgun-go/v4"
 )
 
 // If your plan does not include email validations but you have an account,
@@ -200,8 +196,8 @@ import (
     "os"
     "time"
 
-    "github.com/mailgun/mailgun-go/v3"
-    "github.com/mailgun/mailgun-go/v3/events"
+    "github.com/mailgun/mailgun-go/v4"
+    "github.com/mailgun/mailgun-go/v4/events"
 )
 
 func main() {
@@ -270,7 +266,7 @@ import (
     "log"
     "time"
 
-    "github.com/mailgun/mailgun-go/v3"
+    "github.com/mailgun/mailgun-go/v4"
 )
 
 // Your available domain names can be found here:
@@ -324,13 +320,13 @@ mg.SetAPIBase(mailgun.APIBaseEU)
 ## Installation
 
 If you are using [golang modules](https://github.com/golang/go/wiki/Modules) make sure you
-include the `/v3` at the end of your import paths
+include the `/v4` at the end of your import paths
 ```bash
-$ go get github.com/mailgun/mailgun-go/v3
+$ go get github.com/mailgun/mailgun-go/v4
 ```
 
-If you are **not** using golang modules, you can drop the `/v3` at the end of the import path.
-As long as you are using the latest 1.10 or 1.11 golang release, import paths that end in `/v3`
+If you are **not** using golang modules, you can drop the `/v4` at the end of the import path.
+As long as you are using the latest 1.10 or 1.11 golang release, import paths that end in `/v4`
 in your code should work fine even if you do not have golang modules enabled for your project.
 ```bash
 $ go get github.com/mailgun/mailgun-go
@@ -340,7 +336,7 @@ $ go get github.com/mailgun/mailgun-go
 
 Using version 3 of the mailgun-go library with go dep currently results in the following error
 ```
-"github.com/mailgun/mailgun-go/v3/events", which contains malformed code: no package exists at ...
+"github.com/mailgun/mailgun-go/v4/events", which contains malformed code: no package exists at ...
 ```
 This is a known bug in go dep. You can follow the PR to fix this bug [here](https://github.com/golang/dep/pull/1963)
 Until this bug is fixed, the best way to use version 3 of the mailgun-go library is to use the golang community 

--- a/domains_test.go
+++ b/domains_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 const (

--- a/email_validation_test.go
+++ b/email_validation_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestEmailValidation(t *testing.T) {

--- a/events.go
+++ b/events.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4/events"
 	"github.com/mailru/easyjson"
 )
 

--- a/events_test.go
+++ b/events_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4"
+	"github.com/mailgun/mailgun-go/v4/events"
 )
 
 func TestEventIteratorGetNext(t *testing.T) {

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -3,8 +3,8 @@ package examples
 import (
 	"context"
 	"fmt"
-	"github.com/mailgun/mailgun-go/v3"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4"
+	"github.com/mailgun/mailgun-go/v4/events"
 	"os"
 	"time"
 )

--- a/examples_test.go
+++ b/examples_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mailgun/mailgun-go/v3"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4"
+	"github.com/mailgun/mailgun-go/v4/events"
 )
 
 func ExampleMailgunImpl_ValidateEmail() {

--- a/exports_test.go
+++ b/exports_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestExports(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,6 @@
-module github.com/mailgun/mailgun-go/v3
+module github.com/mailgun/mailgun-go/v4
+
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -8,10 +10,4 @@ require (
 	github.com/go-chi/chi v4.0.0+incompatible
 	github.com/mailru/easyjson v0.7.0
 	github.com/pkg/errors v0.8.1
-	github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 // indirect
-	github.com/ugorji/go v1.1.7 // indirect
 )
-
-replace github.com/mailgun/mailgun-go/v3/events => ./events
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -8,15 +8,7 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQD
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/go-chi/chi v4.0.0+incompatible h1:SiLLEDyAkqNnw+T/uDTf3aFB9T4FTrwMpuYrgaRcnW4=
 github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
-github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7 h1:xoIK0ctDddBMnc74udxJYBqlo9Ylnsp1waqjLsnef20=
-github.com/pquerna/ffjson v0.0.0-20190930134022-aa0246cd15f7/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
-github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
-github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
-github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
-github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=

--- a/ips_test.go
+++ b/ips_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 var server mailgun.MockServer

--- a/limits_test.go
+++ b/limits_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestLimits(t *testing.T) {

--- a/mailgun_test.go
+++ b/mailgun_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 const domain = "valid-mailgun-domain"

--- a/mailing_lists_test.go
+++ b/mailing_lists_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestMailingListMembers(t *testing.T) {

--- a/mock_events.go
+++ b/mock_events.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4/events"
 )
 
 func (ms *MockServer) addEventRoutes(r chi.Router) {

--- a/mock_messages.go
+++ b/mock_messages.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4/events"
 )
 
 func (ms *MockServer) addMessagesRoutes(r chi.Router) {

--- a/parse.go
+++ b/parse.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4/events"
 	"github.com/mailru/easyjson"
 )
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4/events"
 )
 
 func TestParseErrors(t *testing.T) {

--- a/routes_test.go
+++ b/routes_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestRouteCRUD(t *testing.T) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4"
+	"github.com/mailgun/mailgun-go/v4/events"
 	"strings"
 	"testing"
 )

--- a/tags_test.go
+++ b/tags_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 	"github.com/pkg/errors"
 )
 

--- a/template_test.go
+++ b/template_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 	"github.com/pkg/errors"
 )
 

--- a/template_versions_test.go
+++ b/template_versions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestTemplateVersionsCRUD(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package mailgun
 
 // Version of current release
-const Version = "3.6.1"
+const Version = "4.0.0"

--- a/webhooks.go
+++ b/webhooks.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/mailgun/mailgun-go/v3/events"
+	"github.com/mailgun/mailgun-go/v4/events"
 )
 
 type UrlOrUrls struct {

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
-	"github.com/mailgun/mailgun-go/v3"
+	"github.com/mailgun/mailgun-go/v4"
 )
 
 func TestGetWebhook(t *testing.T) {


### PR DESCRIPTION
## Purpose
Due to a non backward compatible change made on `events.UserVariables` we need to bump the major version before release. 