### PR TITLE
Add ListEventsWithDomain

### DIFF
--- a/events.go
+++ b/events.go
@@ -35,9 +35,20 @@ type EventIterator struct {
 	err error
 }
 
+// Create an new iterator to fetch a page of events from the events api with a specific domain
+func (mg *MailgunImpl) ListEventsWithDomain(opts *ListEventOptions, domain string) *EventIterator {
+	url := generateApiUrlWithDomain(mg, eventsEndpoint, domain)
+	return mg.listEvents(url, opts)
+}
+
 // Create an new iterator to fetch a page of events from the events api
 func (mg *MailgunImpl) ListEvents(opts *ListEventOptions) *EventIterator {
-	req := newHTTPRequest(generateApiUrl(mg, eventsEndpoint))
+	url := generateApiUrl(mg, eventsEndpoint)
+	return mg.listEvents(url, opts)
+}
+
+func (mg *MailgunImpl) listEvents(url string, opts *ListEventOptions) *EventIterator {
+	req := newHTTPRequest(url)
 	if opts != nil {
 		if opts.Limit > 0 {
 			req.addParameter("limit", fmt.Sprintf("%d", opts.Limit))


### PR DESCRIPTION
When you have a list of message-id to process, to get the events for each message, and you are working with multiple domains, it is currently not possible to list them unless you make a new client every time a different domain than the current client's domain pop in the list to process.

To avoid that, we added a method ListEventsWithDomain so we can pass the domain as parameter, instead of making a new client instance