### PR TITLE
Fixed failure while testing webhook via mailgun web console

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -84,15 +84,15 @@ func ParseEvent(raw []byte) (Event, error) {
 	}
 
 	// Get the event "constructor" from the map.
-	newEvent, ok := EventNames[e.Name]
+	newEvent, ok := EventNames[e.GetName()]
 	if !ok {
-		return nil, fmt.Errorf("unsupported event: '%s'", e.Name)
+		return nil, fmt.Errorf("unsupported event: '%s'", e.GetName())
 	}
 	event := newEvent()
 
 	// Parse the known event.
 	if err := easyjson.Unmarshal(raw, event); err != nil {
-		return nil, fmt.Errorf("failed to parse event '%s': %v", e.Name, err)
+		return nil, fmt.Errorf("failed to parse event '%s': %v", e.GetName(), err)
 	}
 
 	return event, nil

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package mailgun
 
 // Version of current release
-const Version = "4.0.0"
+const Version = "4.2.0"


### PR DESCRIPTION
### Fixes

Trying to fix the following issues in this pull request,

1. Unable to test with **Webhook Test** on the Web Console ([here](https://app.mailgun.com/app/sending/domains/mg.example.com/webhooks))
2. _(minor)_ outdated version definition

### Detail Information:

The payload of the events `CLICKED`, `OPENED`, `UNSUBSCRIBED` from **Webhook Test** ([here](https://app.mailgun.com/app/sending/domains/mg.example.com/webhooks)) sends out `event` in **upper case**:

```
"event": "OPENED",
"event": "CLICKED",
"event": "UNSUBSCRIBED",
```

but the event `FAILED` in **lower case**.

```
"event": "failed",
```

need to convert them to lower case, or it will failed at `ParseEvent()` as it could not construct `EventNames` with upper case event name: https://github.com/mailgun/mailgun-go/blob/v4.2.0/parse.go#L24-L38

