### PR TITLE
Add UpdateDomainDkimSelector

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -378,6 +378,18 @@ func (mg *MailgunImpl) UpdateOpenTracking(ctx context.Context, domain, active st
 	return err
 }
 
+// Update the DKIM selector for a domain
+func (mg *MailgunImpl) UpdateDomainDkimSelector(ctx context.Context, domain string, dkim_selector string) error {
+	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/dkim_selector")
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+
+	payload := newUrlEncodedPayload()
+	payload.addValue("dkim_selector", dkim_selector)
+	_, err := makePutRequest(ctx, r, payload)
+	return err
+}
+
 func boolToString(b bool) string {
 	if b {
 		return "true"

--- a/domains_test.go
+++ b/domains_test.go
@@ -153,3 +153,13 @@ func TestDomainVerify(t *testing.T) {
 	_, err := mg.VerifyDomain(ctx, testDomain)
 	ensure.Nil(t, err)
 }
+
+func TestDomainDkimSelector(t *testing.T) {
+	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg.SetAPIBase(server.URL())
+	ctx := context.Background()
+
+	// Update Domain DKIM selector
+	err := mg.UpdateDomainDkimSelector(ctx, testDomain, "gotest")
+	ensure.Nil(t, err)
+}


### PR DESCRIPTION
Mailgun API supports update dkim selector for a domain as documented here https://documentation.mailgun.com/en/latest/api-domains.html#domains
I don't see any like that in this library, so I added one, please check. Thank you