### PR TITLE
Add domain web prefix, update naming dkim pram

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -379,13 +379,25 @@ func (mg *MailgunImpl) UpdateOpenTracking(ctx context.Context, domain, active st
 }
 
 // Update the DKIM selector for a domain
-func (mg *MailgunImpl) UpdateDomainDkimSelector(ctx context.Context, domain string, dkim_selector string) error {
+func (mg *MailgunImpl) UpdateDomainDkimSelector(ctx context.Context, domain, dkimSelector string) error {
 	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/dkim_selector")
 	r.setClient(mg.Client())
 	r.setBasicAuth(basicAuthUser, mg.APIKey())
 
 	payload := newUrlEncodedPayload()
-	payload.addValue("dkim_selector", dkim_selector)
+	payload.addValue("dkim_selector", dkimSelector)
+	_, err := makePutRequest(ctx, r, payload)
+	return err
+}
+
+// Update the CNAME used for tracking opens and clicks
+func (mg *MailgunImpl) UpdateDomainTrackingWebPrefix(ctx context.Context, domain, webPrefix string) error {
+	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/web_prefix")
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+
+	payload := newUrlEncodedPayload()
+	payload.addValue("web_prefix", webPrefix)
 	_, err := makePutRequest(ctx, r, payload)
 	return err
 }

--- a/domains_test.go
+++ b/domains_test.go
@@ -163,3 +163,13 @@ func TestDomainDkimSelector(t *testing.T) {
 	err := mg.UpdateDomainDkimSelector(ctx, testDomain, "gotest")
 	ensure.Nil(t, err)
 }
+
+func TestDomainTrackingWebPrefix(t *testing.T) {
+	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg.SetAPIBase(server.URL())
+	ctx := context.Background()
+
+	// Update Domain Tracking Web Prefix
+	err := mg.UpdateDomainTrackingWebPrefix(ctx, testDomain, "gotest")
+	ensure.Nil(t, err)
+}

--- a/mock_domains.go
+++ b/mock_domains.go
@@ -98,6 +98,7 @@ func (ms *MockServer) addDomainRoutes(r chi.Router) {
 	r.Put("/domains/{domain}/tracking/unsubscribe", ms.updateUnsubTracking)
 	r.Get("/domains/{domain}/limits/tag", ms.getTagLimits)
 	r.Put("/domains/{domain}/dkim_selector", ms.updateDKIMSelector)
+	r.Put("/domains/{domain}/web_prefix", ms.updateWebPrefix)
 }
 
 func (ms *MockServer) listDomains(w http.ResponseWriter, r *http.Request) {
@@ -291,6 +292,21 @@ func (ms *MockServer) updateDKIMSelector(w http.ResponseWriter, r *http.Request)
 				return
 			}
 			toJSON(w, okResp{Message: "updated dkim selector"})
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
+	toJSON(w, okResp{Message: "domain not found"})
+}
+
+func (ms *MockServer) updateWebPrefix(w http.ResponseWriter, r *http.Request) {
+	for _, d := range ms.domainList {
+		if d.Domain.Name == chi.URLParam(r, "domain") {
+			if r.FormValue("web_prefix") == "" {
+				toJSON(w, okResp{Message: "web_prefix param required"})
+				return
+			}
+			toJSON(w, okResp{Message: "updated web prefix"})
 			return
 		}
 	}


### PR DESCRIPTION
I noticed updating web prefix for a domain also missing, so I created another PR, please review 
https://documentation.mailgun.com/en/latest/api-domains.html#domains
(I also made slightly change in naming Dkim func created before to follow convention) 