### PR TITLE
Add the Rist to the EmailVerification response attributes

### DIFF
--- a/email_validation.go
+++ b/email_validation.go
@@ -45,6 +45,8 @@ type EmailVerification struct {
 	Reason string `json:"reason"`
 	// A list of potential reasons why a specific validation may be unsuccessful. (Available in the v4 response)
 	Reasons []string
+	// Risk assessment for the provided email.
+	Risk string `json:"risk"`
 }
 
 type v4EmailValidationResp struct {
@@ -56,6 +58,7 @@ type v4EmailValidationResp struct {
 	IsDisposableAddress bool                   `json:"is_disposable_address"`
 	IsRoleAddress       bool                   `json:"is_role_address"`
 	Reason              []string               `json:"reason"`
+	Risk                string                 `json:"risk"`
 }
 
 type addressParseResult struct {
@@ -194,7 +197,8 @@ func (m *EmailValidatorImpl) validateV4(ctx context.Context, email string, mailB
 		DidYouMean:          res.DidYouMean,
 		IsDisposableAddress: res.IsDisposableAddress,
 		IsRoleAddress:       res.IsRoleAddress,
-		Reasons:             res.Reason}, nil
+		Reasons:             res.Reason,
+		Risk:                res.Risk}, nil
 }
 
 // ParseAddresses takes a list of addresses and sorts them into valid and invalid address categories.

--- a/email_validation_test.go
+++ b/email_validation_test.go
@@ -27,6 +27,7 @@ func TestEmailValidationV3(t *testing.T) {
 	ensure.DeepEqual(t, ev.Parts.Domain, "mailgun.com")
 	ensure.DeepEqual(t, ev.Reason, "no-reason")
 	ensure.True(t, len(ev.Reasons) == 0)
+	ensure.DeepEqual(t, ev.Risk, "unknown")
 }
 
 func TestEmailValidationV4(t *testing.T) {
@@ -48,6 +49,7 @@ func TestEmailValidationV4(t *testing.T) {
 	ensure.DeepEqual(t, ev.Reason, "")
 	ensure.True(t, len(ev.Reasons) != 0)
 	ensure.DeepEqual(t, ev.Reasons[0], "no-reason")
+	ensure.DeepEqual(t, ev.Risk, "unknown")
 }
 
 func TestParseAddresses(t *testing.T) {

--- a/mock_validation.go
+++ b/mock_validation.go
@@ -32,6 +32,7 @@ func (ms *MockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {
 		results.Parts.DisplayName = parts.Name
 	}
 	results.Reason = []string{"no-reason"}
+	results.Risk = "unknown"
 	toJSON(w, results)
 }
 
@@ -51,6 +52,7 @@ func (ms *MockServer) validateEmail(w http.ResponseWriter, r *http.Request) {
 		results.Parts.DisplayName = parts.Name
 	}
 	results.Reason = "no-reason"
+	results.Risk = "unknown"
 	toJSON(w, results)
 }
 


### PR DESCRIPTION
**Reference issues/PRs**
None

**What does this implement/fix? Explain your changes.**

Since the API documentation shows that the email validation response contains the `risk` attribute, it would be useful to include it in the struct used to deserialize the response.

The changes add the `Risk` attribute to the `EmailVerification` and `v4EmailValidationResp` structs, add the mapping for the new attribute and expand the tests to also include it.

**Any other comments?**
Is adding it to the V3 test necessary?