### PR TITLE
Bump go-chi to the latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
-	github.com/go-chi/chi v4.0.0+incompatible
+	github.com/go-chi/chi v1.5.2
 	github.com/json-iterator/go v1.1.10
 	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQDg5gKsWoLBOB0n+ZW8s599zru8FJ2/Y=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
-github.com/go-chi/chi v4.0.0+incompatible h1:SiLLEDyAkqNnw+T/uDTf3aFB9T4FTrwMpuYrgaRcnW4=
-github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi v1.5.2 h1:YcLIBANL4OTaAOcTdp//sskGa0yGACQMCtbnr7YEn0Q=
+github.com/go-chi/chi v1.5.2/go.mod h1:REp24E+25iKvxgeTfHmdUoL5x15kBiDBlnIl5bCwe2k=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
Hi there,

First of all, thanks for providing a really neat API to the community, it's been super easy to get up and going.

I've come across a slight issue in the code base that I've integrated this library into however. We're using a mailgun dependency, go-chi, as our main routing handler and the version mismatch is causing resolution issues with go modules. Unfortunately there are some bugs in v4.0.0+incompatible that affect the application quite severely, so we've needed to "upgrade" to v1.5.2. Please see this thread regarding the versioning issue https://github.com/go-chi/chi/issues/561. Basically it all boils down to go modules still having a few teething issues.

My attempts to resolve without raising this PR:

Use the go.mod replace directive: This gets wiped by `go mod tidy` as replace is ignored for sub-dependencies (a bit of an unexpected trap)
Use the go.mod exclude directive: This does stop v4.0.0+incompatible entering, but fails the command unfortunately.

```
go: github.com/mailgun/mailgun-go/v4@v4.3.3: github.com/mailgun/mailgun-go/v4(v4.3.3) depends on excluded github.com/go-chi/chi(v4.0.0+incompatible) with no newer version available
```

My workaround for the moment is to use the forked version of the code until this is able to be merged, or a fix for managing version progression slated for golang v1.16


