### PR TITLE
Swap chi router for gorilla mux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
-	github.com/go-chi/chi v4.0.0+incompatible
+	github.com/gorilla/mux v1.8.0
 	github.com/json-iterator/go v1.1.10
 	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,9 +7,9 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 h1:E2s37DuLxFhQDg5gKsWoLBOB0n+ZW8s599zru8FJ2/Y=
 github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
-github.com/go-chi/chi v4.0.0+incompatible h1:SiLLEDyAkqNnw+T/uDTf3aFB9T4FTrwMpuYrgaRcnW4=
-github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=

--- a/mock.go
+++ b/mock.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 )
 
 // A mailgun api mock suitable for testing
@@ -32,9 +32,9 @@ func NewMockServer() MockServer {
 	ms := MockServer{}
 
 	// Add all our handlers
-	r := chi.NewRouter()
+	r := mux.NewRouter()
 
-	r.Route("/v3", func(r chi.Router) {
+	func(r *mux.Router) {
 		ms.addIPRoutes(r)
 		ms.addExportRoutes(r)
 		ms.addDomainRoutes(r)
@@ -43,7 +43,7 @@ func NewMockServer() MockServer {
 		ms.addMessagesRoutes(r)
 		ms.addRoutes(r)
 		ms.addWebhookRoutes(r)
-	})
+	}(r.PathPrefix("/v3").Subrouter())
 	ms.addValidationRoutes(r)
 
 	// Start the server

--- a/mock_events.go
+++ b/mock_events.go
@@ -5,12 +5,12 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 	"github.com/mailgun/mailgun-go/v4/events"
 )
 
-func (ms *MockServer) addEventRoutes(r chi.Router) {
-	r.Get("/{domain}/events", ms.listEvents)
+func (ms *MockServer) addEventRoutes(r *mux.Router) {
+	r.HandleFunc("/{domain}/events", ms.listEvents).Methods(http.MethodGet)
 
 	var (
 		tags            = []string{"tag1", "tag2"}

--- a/mock_exports.go
+++ b/mock_exports.go
@@ -4,14 +4,14 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addExportRoutes(r chi.Router) {
-	r.Post("/exports", ms.postExports)
-	r.Get("/exports", ms.listExports)
-	r.Get("/exports/{id}", ms.getExport)
-	r.Get("/exports/{id}/download_url", ms.getExportLink)
+func (ms *MockServer) addExportRoutes(r *mux.Router) {
+	r.HandleFunc("/exports", ms.postExports).Methods(http.MethodPost)
+	r.HandleFunc("/exports", ms.listExports).Methods(http.MethodGet)
+	r.HandleFunc("/exports/{id}", ms.getExport).Methods(http.MethodGet)
+	r.HandleFunc("/exports/{id}/download_url", ms.getExportLink).Methods(http.MethodGet)
 }
 
 func (ms *MockServer) postExports(w http.ResponseWriter, r *http.Request) {
@@ -33,7 +33,7 @@ func (ms *MockServer) listExports(w http.ResponseWriter, _ *http.Request) {
 
 func (ms *MockServer) getExport(w http.ResponseWriter, r *http.Request) {
 	for _, export := range ms.exportList {
-		if export.ID == chi.URLParam(r, "id") {
+		if export.ID == mux.Vars(r)["id"] {
 			toJSON(w, export)
 			return
 		}

--- a/mock_ips.go
+++ b/mock_ips.go
@@ -3,18 +3,18 @@ package mailgun
 import (
 	"net/http"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addIPRoutes(r chi.Router) {
-	r.Get("/ips", ms.listIPS)
-	r.Get("/ips/{ip}", ms.getIPAddress)
-	r.Route("/domains/{domain}/ips", func(r chi.Router) {
-		r.Get("/", ms.listDomainIPS)
-		r.Get("/{ip}", ms.getIPAddress)
-		r.Post("/", ms.postDomainIPS)
-		r.Delete("/{ip}", ms.deleteDomainIPS)
-	})
+func (ms *MockServer) addIPRoutes(r *mux.Router) {
+	r.HandleFunc("/ips", ms.listIPS).Methods(http.MethodGet)
+	r.HandleFunc("/ips/{ip}", ms.getIPAddress).Methods(http.MethodGet)
+	func(r *mux.Router) {
+		r.HandleFunc("", ms.listDomainIPS).Methods(http.MethodGet)
+		r.HandleFunc("/{ip}", ms.getIPAddress).Methods(http.MethodGet)
+		r.HandleFunc("", ms.postDomainIPS).Methods(http.MethodPost)
+		r.HandleFunc("/{ip}", ms.deleteDomainIPS).Methods(http.MethodDelete)
+	}(r.PathPrefix("/domains/{domain}/ips").Subrouter())
 }
 
 func (ms *MockServer) listIPS(w http.ResponseWriter, _ *http.Request) {
@@ -26,7 +26,7 @@ func (ms *MockServer) listIPS(w http.ResponseWriter, _ *http.Request) {
 
 func (ms *MockServer) getIPAddress(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, IPAddress{
-		IP:        chi.URLParam(r, "ip"),
+		IP:        mux.Vars(r)["ip"],
 		RDNS:      "luna.mailgun.net",
 		Dedicated: true,
 	})
@@ -47,7 +47,7 @@ func (ms *MockServer) postDomainIPS(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) deleteDomainIPS(w http.ResponseWriter, r *http.Request) {
 	result := ms.domainIPS[:0]
 	for _, ip := range ms.domainIPS {
-		if ip == chi.URLParam(r, "ip") {
+		if ip == mux.Vars(r)["ip"] {
 			continue
 		}
 		result = append(result, ip)

--- a/mock_mailing_list.go
+++ b/mock_mailing_list.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 )
 
 type mailingListContainer struct {
@@ -14,19 +14,19 @@ type mailingListContainer struct {
 	Members     []Member
 }
 
-func (ms *MockServer) addMailingListRoutes(r chi.Router) {
-	r.Get("/lists/pages", ms.listMailingLists)
-	r.Get("/lists/{address}", ms.getMailingList)
-	r.Post("/lists", ms.createMailingList)
-	r.Put("/lists/{address}", ms.updateMailingList)
-	r.Delete("/lists/{address}", ms.deleteMailingList)
+func (ms *MockServer) addMailingListRoutes(r *mux.Router) {
+	r.HandleFunc("/lists/pages", ms.listMailingLists).Methods(http.MethodGet)
+	r.HandleFunc("/lists/{address}", ms.getMailingList).Methods(http.MethodGet)
+	r.HandleFunc("/lists", ms.createMailingList).Methods(http.MethodPost)
+	r.HandleFunc("/lists/{address}", ms.updateMailingList).Methods(http.MethodPut)
+	r.HandleFunc("/lists/{address}", ms.deleteMailingList).Methods(http.MethodDelete)
 
-	r.Get("/lists/{address}/members/pages", ms.listMembers)
-	r.Get("/lists/{address}/members/{member}", ms.getMember)
-	r.Post("/lists/{address}/members", ms.createMember)
-	r.Put("/lists/{address}/members/{member}", ms.updateMember)
-	r.Delete("/lists/{address}/members/{member}", ms.deleteMember)
-	r.Post("/lists/{address}/members.json", ms.bulkCreate)
+	r.HandleFunc("/lists/{address}/members/pages", ms.listMembers).Methods(http.MethodGet)
+	r.HandleFunc("/lists/{address}/members/{member}", ms.getMember).Methods(http.MethodGet)
+	r.HandleFunc("/lists/{address}/members", ms.createMember).Methods(http.MethodPost)
+	r.HandleFunc("/lists/{address}/members/{member}", ms.updateMember).Methods(http.MethodPut)
+	r.HandleFunc("/lists/{address}/members/{member}", ms.deleteMember).Methods(http.MethodDelete)
+	r.HandleFunc("/lists/{address}/members.json", ms.bulkCreate).Methods(http.MethodPost)
 
 	ms.mailingList = append(ms.mailingList, mailingListContainer{
 		MailingList: MailingList{
@@ -91,7 +91,7 @@ func (ms *MockServer) listMailingLists(w http.ResponseWriter, r *http.Request) {
 
 func (ms *MockServer) getMailingList(w http.ResponseWriter, r *http.Request) {
 	for _, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			toJSON(w, mailingListResponse{MailingList: ml.MailingList})
 			return
 		}
@@ -103,7 +103,7 @@ func (ms *MockServer) getMailingList(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) deleteMailingList(w http.ResponseWriter, r *http.Request) {
 	result := ms.mailingList[:0]
 	for _, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			continue
 		}
 		result = append(result, ml)
@@ -121,7 +121,7 @@ func (ms *MockServer) deleteMailingList(w http.ResponseWriter, r *http.Request) 
 
 func (ms *MockServer) updateMailingList(w http.ResponseWriter, r *http.Request) {
 	for i, d := range ms.mailingList {
-		if d.MailingList.Address == chi.URLParam(r, "address") {
+		if d.MailingList.Address == mux.Vars(r)["address"] {
 			if r.FormValue("address") != "" {
 				ms.mailingList[i].MailingList.Address = r.FormValue("address")
 			}
@@ -161,7 +161,7 @@ func (ms *MockServer) listMembers(w http.ResponseWriter, r *http.Request) {
 	var found bool
 
 	for _, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			found = true
 			for _, member := range ml.Members {
 				list = append(list, member)
@@ -213,10 +213,10 @@ func (ms *MockServer) listMembers(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) getMember(w http.ResponseWriter, r *http.Request) {
 	var found bool
 	for _, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			found = true
 			for _, member := range ml.Members {
-				if member.Address == chi.URLParam(r, "member") {
+				if member.Address == mux.Vars(r)["member"] {
 					toJSON(w, memberResponse{Member: member})
 					return
 				}
@@ -237,7 +237,7 @@ func (ms *MockServer) getMember(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) deleteMember(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			idx = i
 		}
 	}
@@ -250,7 +250,7 @@ func (ms *MockServer) deleteMember(w http.ResponseWriter, r *http.Request) {
 
 	result := ms.mailingList[idx].Members[:0]
 	for _, m := range ms.mailingList[idx].Members {
-		if m.Address == chi.URLParam(r, "member") {
+		if m.Address == mux.Vars(r)["member"] {
 			continue
 		}
 		result = append(result, m)
@@ -269,7 +269,7 @@ func (ms *MockServer) deleteMember(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) updateMember(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			idx = i
 		}
 	}
@@ -281,7 +281,7 @@ func (ms *MockServer) updateMember(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for i, m := range ms.mailingList[idx].Members {
-		if m.Address == chi.URLParam(r, "member") {
+		if m.Address == mux.Vars(r)["member"] {
 			if r.FormValue("address") != "" {
 				ms.mailingList[idx].Members[i].Address = parseAddress(r.FormValue("address"))
 			}
@@ -306,7 +306,7 @@ func (ms *MockServer) updateMember(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) createMember(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			idx = i
 		}
 	}
@@ -349,7 +349,7 @@ func (ms *MockServer) createMember(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) bulkCreate(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
-		if ml.MailingList.Address == chi.URLParam(r, "address") {
+		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			idx = i
 		}
 	}

--- a/mock_messages.go
+++ b/mock_messages.go
@@ -6,16 +6,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 	"github.com/mailgun/mailgun-go/v4/events"
 )
 
-func (ms *MockServer) addMessagesRoutes(r chi.Router) {
-	r.Post("/{domain}/messages", ms.createMessages)
+func (ms *MockServer) addMessagesRoutes(r *mux.Router) {
+	r.HandleFunc("/{domain}/messages", ms.createMessages).Methods(http.MethodPost)
 
 	// This path is made up; it could be anything as the storage url could change over time
-	r.Get("/se.storage.url/messages/{id}", ms.getStoredMessages)
-	r.Post("/se.storage.url/messages/{id}", ms.sendStoredMessages)
+	r.HandleFunc("/se.storage.url/messages/{id}", ms.getStoredMessages).Methods(http.MethodGet)
+	r.HandleFunc("/se.storage.url/messages/{id}", ms.sendStoredMessages).Methods(http.MethodPost)
 }
 
 // TODO: This implementation doesn't support multiple recipients
@@ -83,7 +83,7 @@ func (ms *MockServer) createMessages(w http.ResponseWriter, r *http.Request) {
 }
 
 func (ms *MockServer) getStoredMessages(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := mux.Vars(r)["id"]
 
 	// Find our stored event
 	var stored *events.Stored
@@ -113,7 +113,7 @@ func (ms *MockServer) getStoredMessages(w http.ResponseWriter, r *http.Request) 
 }
 
 func (ms *MockServer) sendStoredMessages(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+	id := mux.Vars(r)["id"]
 
 	// Find our stored event
 	var stored *events.Stored

--- a/mock_routes.go
+++ b/mock_routes.go
@@ -2,21 +2,22 @@ package mailgun
 
 import (
 	"fmt"
-	"github.com/go-chi/chi"
 	"net/http"
 	"time"
+
+	"github.com/gorilla/mux"
 )
 
 type routeResponse struct {
 	Route Route `json:"route"`
 }
 
-func (ms *MockServer) addRoutes(r chi.Router) {
-	r.Post("/routes", ms.createRoute)
-	r.Get("/routes", ms.listRoutes)
-	r.Get("/routes/{id}", ms.getRoute)
-	r.Put("/routes/{id}", ms.updateRoute)
-	r.Delete("/routes/{id}", ms.deleteRoute)
+func (ms *MockServer) addRoutes(r *mux.Router) {
+	r.HandleFunc("/routes", ms.createRoute).Methods(http.MethodPost)
+	r.HandleFunc("/routes", ms.listRoutes).Methods(http.MethodGet)
+	r.HandleFunc("/routes/{id}", ms.getRoute).Methods(http.MethodGet)
+	r.HandleFunc("/routes/{id}", ms.updateRoute).Methods(http.MethodPut)
+	r.HandleFunc("/routes/{id}", ms.deleteRoute).Methods(http.MethodDelete)
 
 	for i := 0; i < 10; i++ {
 		ms.routeList = append(ms.routeList, Route{
@@ -65,7 +66,7 @@ func (ms *MockServer) listRoutes(w http.ResponseWriter, r *http.Request) {
 
 func (ms *MockServer) getRoute(w http.ResponseWriter, r *http.Request) {
 	for _, item := range ms.routeList {
-		if item.Id == chi.URLParam(r, "id") {
+		if item.Id == mux.Vars(r)["id"] {
 			toJSON(w, routeResponse{Route: item})
 			return
 		}
@@ -97,7 +98,7 @@ func (ms *MockServer) createRoute(w http.ResponseWriter, r *http.Request) {
 
 func (ms *MockServer) updateRoute(w http.ResponseWriter, r *http.Request) {
 	for i, item := range ms.routeList {
-		if item.Id == chi.URLParam(r, "id") {
+		if item.Id == mux.Vars(r)["id"] {
 
 			if r.FormValue("action") != "" {
 				ms.routeList[i].Actions = r.Form["action"]
@@ -122,7 +123,7 @@ func (ms *MockServer) updateRoute(w http.ResponseWriter, r *http.Request) {
 func (ms *MockServer) deleteRoute(w http.ResponseWriter, r *http.Request) {
 	result := ms.routeList[:0]
 	for _, item := range ms.routeList {
-		if item.Id == chi.URLParam(r, "id") {
+		if item.Id == mux.Vars(r)["id"] {
 			continue
 		}
 		result = append(result, item)

--- a/mock_validation.go
+++ b/mock_validation.go
@@ -5,15 +5,15 @@ import (
 	"net/mail"
 	"strings"
 
-	"github.com/go-chi/chi"
+	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addValidationRoutes(r chi.Router) {
-	r.Get("/v3/address/validate", ms.validateEmail)
-	r.Get("/v3/address/parse", ms.parseEmail)
-	r.Get("/v3/address/private/validate", ms.validateEmail)
-	r.Get("/v3/address/private/parse", ms.parseEmail)
-	r.Get("/v4/address/validate", ms.validateEmailV4)
+func (ms *MockServer) addValidationRoutes(r *mux.Router) {
+	r.HandleFunc("/v3/address/validate", ms.validateEmail).Methods(http.MethodGet)
+	r.HandleFunc("/v3/address/parse", ms.parseEmail).Methods(http.MethodGet)
+	r.HandleFunc("/v3/address/private/validate", ms.validateEmail).Methods(http.MethodGet)
+	r.HandleFunc("/v3/address/private/parse", ms.parseEmail).Methods(http.MethodGet)
+	r.HandleFunc("/v4/address/validate", ms.validateEmailV4).Methods(http.MethodGet)
 }
 
 func (ms *MockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Given https://github.com/go-chi/chi/issues/561 and https://www.reddit.com/r/golang/comments/lpjp8o/gochi_is_retracting_all_major_versions_with_go116/ and the fact that this lib is only relying on chi for testing and mocking I propose moving to github.com/gorilla/mux as an older more stable router.

This would fix https://github.com/mailgun/mailgun-go/issues/251 and prevent needing to https://github.com/mailgun/mailgun-go/pull/245 every time chi decides to retract code.