### PR TITLE
MockServer is now an interface

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -14,22 +14,63 @@ import (
 	"github.com/gorilla/mux"
 )
 
+type MockServer interface {
+	Stop()
+	URL4() string
+	URL() string
+	DomainIPS() []string
+	DomainList() []DomainContainer
+	ExportList() []Export
+	MailingList() []MailingListContainer
+	RouteList() []Route
+	Events() []Event
+	Webhooks() WebHooksListResponse
+}
+
 // A mailgun api mock suitable for testing
-type MockServer struct {
+type mockServer struct {
 	srv *httptest.Server
 
 	domainIPS   []string
-	domainList  []domainContainer
+	domainList  []DomainContainer
 	exportList  []Export
-	mailingList []mailingListContainer
+	mailingList []MailingListContainer
 	routeList   []Route
 	events      []Event
 	webhooks    WebHooksListResponse
 }
 
+func (ms *mockServer) DomainIPS() []string {
+	return ms.domainIPS
+}
+
+func (ms *mockServer) DomainList() []DomainContainer {
+	return ms.domainList
+}
+
+func (ms *mockServer) ExportList() []Export {
+	return ms.exportList
+}
+
+func (ms *mockServer) MailingList() []MailingListContainer {
+	return ms.mailingList
+}
+
+func (ms *mockServer) RouteList() []Route {
+	return ms.routeList
+}
+
+func (ms *mockServer) Events() []Event {
+	return ms.events
+}
+
+func (ms *mockServer) Webhooks() WebHooksListResponse {
+	return ms.webhooks
+}
+
 // Create a new instance of the mailgun API mock server
 func NewMockServer() MockServer {
-	ms := MockServer{}
+	ms := mockServer{}
 
 	// Add all our handlers
 	r := mux.NewRouter()
@@ -48,20 +89,20 @@ func NewMockServer() MockServer {
 
 	// Start the server
 	ms.srv = httptest.NewServer(r)
-	return ms
+	return &ms
 }
 
 // Stop the server
-func (ms *MockServer) Stop() {
+func (ms *mockServer) Stop() {
 	ms.srv.Close()
 }
 
-func (ms *MockServer) URL4() string {
+func (ms *mockServer) URL4() string {
 	return ms.srv.URL + "/v4"
 }
 
 // URL returns the URL used to connect to the mock server
-func (ms *MockServer) URL() string {
+func (ms *mockServer) URL() string {
 	return ms.srv.URL + "/v3"
 }
 

--- a/mock_domains.go
+++ b/mock_domains.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type domainContainer struct {
+type DomainContainer struct {
 	Domain              Domain            `json:"domain"`
 	ReceivingDNSRecords []DNSRecord       `json:"receiving_dns_records"`
 	SendingDNSRecords   []DNSRecord       `json:"sending_dns_records"`
@@ -16,9 +16,9 @@ type domainContainer struct {
 	TagLimits           *TagLimits        `json:"limits,omitempty"`
 }
 
-func (ms *MockServer) addDomainRoutes(r *mux.Router) {
+func (ms *mockServer) addDomainRoutes(r *mux.Router) {
 
-	ms.domainList = append(ms.domainList, domainContainer{
+	ms.domainList = append(ms.domainList, DomainContainer{
 		Domain: Domain{
 			CreatedAt:    RFC2822Time(time.Now().UTC()),
 			Name:         "mailgun.test",
@@ -101,7 +101,7 @@ func (ms *MockServer) addDomainRoutes(r *mux.Router) {
 	r.HandleFunc("/domains/{domain}/web_prefix", ms.updateWebPrefix).Methods(http.MethodPut)
 }
 
-func (ms *MockServer) listDomains(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) listDomains(w http.ResponseWriter, r *http.Request) {
 	var list []Domain
 	for _, domain := range ms.domainList {
 		list = append(list, domain.Domain)
@@ -137,7 +137,7 @@ func (ms *MockServer) listDomains(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (ms *MockServer) getDomain(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getDomain(w http.ResponseWriter, r *http.Request) {
 	for _, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			d.Connection = nil
@@ -149,8 +149,8 @@ func (ms *MockServer) getDomain(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) createDomain(w http.ResponseWriter, r *http.Request) {
-	ms.domainList = append(ms.domainList, domainContainer{
+func (ms *mockServer) createDomain(w http.ResponseWriter, r *http.Request) {
+	ms.domainList = append(ms.domainList, DomainContainer{
 		Domain: Domain{
 			CreatedAt:    RFC2822Time(time.Now()),
 			Name:         r.FormValue("name"),
@@ -164,7 +164,7 @@ func (ms *MockServer) createDomain(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "Domain has been created"})
 }
 
-func (ms *MockServer) deleteDomain(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) deleteDomain(w http.ResponseWriter, r *http.Request) {
 	result := ms.domainList[:0]
 	for _, domain := range ms.domainList {
 		if domain.Domain.Name == mux.Vars(r)["domain"] {
@@ -183,7 +183,7 @@ func (ms *MockServer) deleteDomain(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) getConnection(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getConnection(w http.ResponseWriter, r *http.Request) {
 	for _, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			resp := domainConnectionResponse{
@@ -197,7 +197,7 @@ func (ms *MockServer) getConnection(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) updateConnection(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateConnection(w http.ResponseWriter, r *http.Request) {
 	for i, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			ms.domainList[i].Connection = &DomainConnection{
@@ -212,7 +212,7 @@ func (ms *MockServer) updateConnection(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) getTracking(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getTracking(w http.ResponseWriter, r *http.Request) {
 	for _, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			resp := domainTrackingResponse{
@@ -226,7 +226,7 @@ func (ms *MockServer) getTracking(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) updateClickTracking(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateClickTracking(w http.ResponseWriter, r *http.Request) {
 	for i, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			ms.domainList[i].Tracking.Click.Active = stringToBool(r.FormValue("active"))
@@ -238,7 +238,7 @@ func (ms *MockServer) updateClickTracking(w http.ResponseWriter, r *http.Request
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) updateOpenTracking(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateOpenTracking(w http.ResponseWriter, r *http.Request) {
 	for i, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			ms.domainList[i].Tracking.Open.Active = stringToBool(r.FormValue("active"))
@@ -250,7 +250,7 @@ func (ms *MockServer) updateOpenTracking(w http.ResponseWriter, r *http.Request)
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) updateUnsubTracking(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateUnsubTracking(w http.ResponseWriter, r *http.Request) {
 	for i, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			ms.domainList[i].Tracking.Unsubscribe.Active = stringToBool(r.FormValue("active"))
@@ -268,7 +268,7 @@ func (ms *MockServer) updateUnsubTracking(w http.ResponseWriter, r *http.Request
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) getTagLimits(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getTagLimits(w http.ResponseWriter, r *http.Request) {
 	for _, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			if d.TagLimits == nil {
@@ -284,7 +284,7 @@ func (ms *MockServer) getTagLimits(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) updateDKIMSelector(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateDKIMSelector(w http.ResponseWriter, r *http.Request) {
 	for _, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			if r.FormValue("dkim_selector") == "" {
@@ -299,7 +299,7 @@ func (ms *MockServer) updateDKIMSelector(w http.ResponseWriter, r *http.Request)
 	toJSON(w, okResp{Message: "domain not found"})
 }
 
-func (ms *MockServer) updateWebPrefix(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateWebPrefix(w http.ResponseWriter, r *http.Request) {
 	for _, d := range ms.domainList {
 		if d.Domain.Name == mux.Vars(r)["domain"] {
 			if r.FormValue("web_prefix") == "" {

--- a/mock_events.go
+++ b/mock_events.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mailgun/mailgun-go/v4/events"
 )
 
-func (ms *MockServer) addEventRoutes(r *mux.Router) {
+func (ms *mockServer) addEventRoutes(r *mux.Router) {
 	r.HandleFunc("/{domain}/events", ms.listEvents).Methods(http.MethodGet)
 
 	var (
@@ -193,7 +193,7 @@ type eventsResponse struct {
 	Paging Paging  `json:"paging"`
 }
 
-func (ms *MockServer) listEvents(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) listEvents(w http.ResponseWriter, r *http.Request) {
 	var idx []string
 
 	for _, e := range ms.events {

--- a/mock_exports.go
+++ b/mock_exports.go
@@ -7,14 +7,14 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addExportRoutes(r *mux.Router) {
+func (ms *mockServer) addExportRoutes(r *mux.Router) {
 	r.HandleFunc("/exports", ms.postExports).Methods(http.MethodPost)
 	r.HandleFunc("/exports", ms.listExports).Methods(http.MethodGet)
 	r.HandleFunc("/exports/{id}", ms.getExport).Methods(http.MethodGet)
 	r.HandleFunc("/exports/{id}/download_url", ms.getExportLink).Methods(http.MethodGet)
 }
 
-func (ms *MockServer) postExports(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) postExports(w http.ResponseWriter, r *http.Request) {
 	e := Export{
 		ID:     strconv.Itoa(len(ms.exportList)),
 		URL:    r.FormValue("url"),
@@ -25,13 +25,13 @@ func (ms *MockServer) postExports(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "success"})
 }
 
-func (ms *MockServer) listExports(w http.ResponseWriter, _ *http.Request) {
+func (ms *mockServer) listExports(w http.ResponseWriter, _ *http.Request) {
 	toJSON(w, ExportList{
 		Items: ms.exportList,
 	})
 }
 
-func (ms *MockServer) getExport(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getExport(w http.ResponseWriter, r *http.Request) {
 	for _, export := range ms.exportList {
 		if export.ID == mux.Vars(r)["id"] {
 			toJSON(w, export)
@@ -42,7 +42,7 @@ func (ms *MockServer) getExport(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "export not found"})
 }
 
-func (ms *MockServer) getExportLink(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getExportLink(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Location", "/some/s3/url")
 	w.WriteHeader(http.StatusFound)
 }

--- a/mock_ips.go
+++ b/mock_ips.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addIPRoutes(r *mux.Router) {
+func (ms *mockServer) addIPRoutes(r *mux.Router) {
 	r.HandleFunc("/ips", ms.listIPS).Methods(http.MethodGet)
 	r.HandleFunc("/ips/{ip}", ms.getIPAddress).Methods(http.MethodGet)
 	func(r *mux.Router) {
@@ -17,14 +17,14 @@ func (ms *MockServer) addIPRoutes(r *mux.Router) {
 	}(r.PathPrefix("/domains/{domain}/ips").Subrouter())
 }
 
-func (ms *MockServer) listIPS(w http.ResponseWriter, _ *http.Request) {
+func (ms *mockServer) listIPS(w http.ResponseWriter, _ *http.Request) {
 	toJSON(w, ipAddressListResponse{
 		TotalCount: 2,
 		Items:      []string{"172.0.0.1", "192.168.1.1"},
 	})
 }
 
-func (ms *MockServer) getIPAddress(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getIPAddress(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, IPAddress{
 		IP:        mux.Vars(r)["ip"],
 		RDNS:      "luna.mailgun.net",
@@ -32,19 +32,19 @@ func (ms *MockServer) getIPAddress(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (ms *MockServer) listDomainIPS(w http.ResponseWriter, _ *http.Request) {
+func (ms *mockServer) listDomainIPS(w http.ResponseWriter, _ *http.Request) {
 	toJSON(w, ipAddressListResponse{
 		TotalCount: 2,
 		Items:      ms.domainIPS,
 	})
 }
 
-func (ms *MockServer) postDomainIPS(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) postDomainIPS(w http.ResponseWriter, r *http.Request) {
 	ms.domainIPS = append(ms.domainIPS, r.FormValue("ip"))
 	toJSON(w, okResp{Message: "success"})
 }
 
-func (ms *MockServer) deleteDomainIPS(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) deleteDomainIPS(w http.ResponseWriter, r *http.Request) {
 	result := ms.domainIPS[:0]
 	for _, ip := range ms.domainIPS {
 		if ip == mux.Vars(r)["ip"] {

--- a/mock_mailing_list.go
+++ b/mock_mailing_list.go
@@ -9,12 +9,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type mailingListContainer struct {
+type MailingListContainer struct {
 	MailingList MailingList
 	Members     []Member
 }
 
-func (ms *MockServer) addMailingListRoutes(r *mux.Router) {
+func (ms *mockServer) addMailingListRoutes(r *mux.Router) {
 	r.HandleFunc("/lists/pages", ms.listMailingLists).Methods(http.MethodGet)
 	r.HandleFunc("/lists/{address}", ms.getMailingList).Methods(http.MethodGet)
 	r.HandleFunc("/lists", ms.createMailingList).Methods(http.MethodPost)
@@ -28,7 +28,7 @@ func (ms *MockServer) addMailingListRoutes(r *mux.Router) {
 	r.HandleFunc("/lists/{address}/members/{member}", ms.deleteMember).Methods(http.MethodDelete)
 	r.HandleFunc("/lists/{address}/members.json", ms.bulkCreate).Methods(http.MethodPost)
 
-	ms.mailingList = append(ms.mailingList, mailingListContainer{
+	ms.mailingList = append(ms.mailingList, MailingListContainer{
 		MailingList: MailingList{
 			AccessLevel:  "everyone",
 			Address:      "foo@mailgun.test",
@@ -46,7 +46,7 @@ func (ms *MockServer) addMailingListRoutes(r *mux.Router) {
 	})
 }
 
-func (ms *MockServer) listMailingLists(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) listMailingLists(w http.ResponseWriter, r *http.Request) {
 	var list []MailingList
 	var idx []string
 
@@ -89,7 +89,7 @@ func (ms *MockServer) listMailingLists(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, resp)
 }
 
-func (ms *MockServer) getMailingList(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getMailingList(w http.ResponseWriter, r *http.Request) {
 	for _, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {
 			toJSON(w, mailingListResponse{MailingList: ml.MailingList})
@@ -100,7 +100,7 @@ func (ms *MockServer) getMailingList(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "mailing list not found"})
 }
 
-func (ms *MockServer) deleteMailingList(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) deleteMailingList(w http.ResponseWriter, r *http.Request) {
 	result := ms.mailingList[:0]
 	for _, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {
@@ -119,7 +119,7 @@ func (ms *MockServer) deleteMailingList(w http.ResponseWriter, r *http.Request) 
 	toJSON(w, okResp{Message: "mailing list not found"})
 }
 
-func (ms *MockServer) updateMailingList(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateMailingList(w http.ResponseWriter, r *http.Request) {
 	for i, d := range ms.mailingList {
 		if d.MailingList.Address == mux.Vars(r)["address"] {
 			if r.FormValue("address") != "" {
@@ -142,8 +142,8 @@ func (ms *MockServer) updateMailingList(w http.ResponseWriter, r *http.Request) 
 	toJSON(w, okResp{Message: "mailing list not found"})
 }
 
-func (ms *MockServer) createMailingList(w http.ResponseWriter, r *http.Request) {
-	ms.mailingList = append(ms.mailingList, mailingListContainer{
+func (ms *mockServer) createMailingList(w http.ResponseWriter, r *http.Request) {
+	ms.mailingList = append(ms.mailingList, MailingListContainer{
 		MailingList: MailingList{
 			CreatedAt:   RFC2822Time(time.Now().UTC()),
 			Name:        r.FormValue("name"),
@@ -155,7 +155,7 @@ func (ms *MockServer) createMailingList(w http.ResponseWriter, r *http.Request) 
 	toJSON(w, okResp{Message: "Mailing list has been created"})
 }
 
-func (ms *MockServer) listMembers(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) listMembers(w http.ResponseWriter, r *http.Request) {
 	var list []Member
 	var idx []string
 	var found bool
@@ -210,7 +210,7 @@ func (ms *MockServer) listMembers(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, resp)
 }
 
-func (ms *MockServer) getMember(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getMember(w http.ResponseWriter, r *http.Request) {
 	var found bool
 	for _, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {
@@ -234,7 +234,7 @@ func (ms *MockServer) getMember(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "member not found"})
 }
 
-func (ms *MockServer) deleteMember(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) deleteMember(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {
@@ -266,7 +266,7 @@ func (ms *MockServer) deleteMember(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "member not found"})
 }
 
-func (ms *MockServer) updateMember(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateMember(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {
@@ -303,7 +303,7 @@ func (ms *MockServer) updateMember(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "member not found"})
 }
 
-func (ms *MockServer) createMember(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) createMember(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {
@@ -346,7 +346,7 @@ func (ms *MockServer) createMember(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "Mailing list member has been created"})
 }
 
-func (ms *MockServer) bulkCreate(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) bulkCreate(w http.ResponseWriter, r *http.Request) {
 	idx := -1
 	for i, ml := range ms.mailingList {
 		if ml.MailingList.Address == mux.Vars(r)["address"] {

--- a/mock_messages.go
+++ b/mock_messages.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mailgun/mailgun-go/v4/events"
 )
 
-func (ms *MockServer) addMessagesRoutes(r *mux.Router) {
+func (ms *mockServer) addMessagesRoutes(r *mux.Router) {
 	r.HandleFunc("/{domain}/messages", ms.createMessages).Methods(http.MethodPost)
 
 	// This path is made up; it could be anything as the storage url could change over time
@@ -19,7 +19,7 @@ func (ms *MockServer) addMessagesRoutes(r *mux.Router) {
 }
 
 // TODO: This implementation doesn't support multiple recipients
-func (ms *MockServer) createMessages(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) createMessages(w http.ResponseWriter, r *http.Request) {
 	to, err := mail.ParseAddress(r.FormValue("to"))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -82,7 +82,7 @@ func (ms *MockServer) createMessages(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{ID: "<" + id + ">", Message: "Queued. Thank you."})
 }
 
-func (ms *MockServer) getStoredMessages(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getStoredMessages(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 
 	// Find our stored event
@@ -112,7 +112,7 @@ func (ms *MockServer) getStoredMessages(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-func (ms *MockServer) sendStoredMessages(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) sendStoredMessages(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 
 	// Find our stored event

--- a/mock_routes.go
+++ b/mock_routes.go
@@ -12,7 +12,7 @@ type routeResponse struct {
 	Route Route `json:"route"`
 }
 
-func (ms *MockServer) addRoutes(r *mux.Router) {
+func (ms *mockServer) addRoutes(r *mux.Router) {
 	r.HandleFunc("/routes", ms.createRoute).Methods(http.MethodPost)
 	r.HandleFunc("/routes", ms.listRoutes).Methods(http.MethodGet)
 	r.HandleFunc("/routes/{id}", ms.getRoute).Methods(http.MethodGet)
@@ -33,7 +33,7 @@ func (ms *MockServer) addRoutes(r *mux.Router) {
 	}
 }
 
-func (ms *MockServer) listRoutes(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) listRoutes(w http.ResponseWriter, r *http.Request) {
 	skip := stringToInt(r.FormValue("skip"))
 	limit := stringToInt(r.FormValue("limit"))
 	if limit == 0 {
@@ -64,7 +64,7 @@ func (ms *MockServer) listRoutes(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (ms *MockServer) getRoute(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getRoute(w http.ResponseWriter, r *http.Request) {
 	for _, item := range ms.routeList {
 		if item.Id == mux.Vars(r)["id"] {
 			toJSON(w, routeResponse{Route: item})
@@ -75,7 +75,7 @@ func (ms *MockServer) getRoute(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "route not found"})
 }
 
-func (ms *MockServer) createRoute(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) createRoute(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("action") == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		toJSON(w, okResp{Message: "'action' parameter is required"})
@@ -96,7 +96,7 @@ func (ms *MockServer) createRoute(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (ms *MockServer) updateRoute(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) updateRoute(w http.ResponseWriter, r *http.Request) {
 	for i, item := range ms.routeList {
 		if item.Id == mux.Vars(r)["id"] {
 
@@ -120,7 +120,7 @@ func (ms *MockServer) updateRoute(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "route not found"})
 }
 
-func (ms *MockServer) deleteRoute(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) deleteRoute(w http.ResponseWriter, r *http.Request) {
 	result := ms.routeList[:0]
 	for _, item := range ms.routeList {
 		if item.Id == mux.Vars(r)["id"] {

--- a/mock_validation.go
+++ b/mock_validation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addValidationRoutes(r *mux.Router) {
+func (ms *mockServer) addValidationRoutes(r *mux.Router) {
 	r.HandleFunc("/v3/address/validate", ms.validateEmail).Methods(http.MethodGet)
 	r.HandleFunc("/v3/address/parse", ms.parseEmail).Methods(http.MethodGet)
 	r.HandleFunc("/v3/address/private/validate", ms.validateEmail).Methods(http.MethodGet)
@@ -16,7 +16,7 @@ func (ms *MockServer) addValidationRoutes(r *mux.Router) {
 	r.HandleFunc("/v4/address/validate", ms.validateEmailV4).Methods(http.MethodGet)
 }
 
-func (ms *MockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("address") == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		toJSON(w, okResp{Message: "'address' parameter is required"})
@@ -36,7 +36,7 @@ func (ms *MockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, results)
 }
 
-func (ms *MockServer) validateEmail(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) validateEmail(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("address") == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		toJSON(w, okResp{Message: "'address' parameter is required"})
@@ -56,7 +56,7 @@ func (ms *MockServer) validateEmail(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, results)
 }
 
-func (ms *MockServer) parseEmail(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) parseEmail(w http.ResponseWriter, r *http.Request) {
 	if r.FormValue("addresses") == "" {
 		w.WriteHeader(http.StatusBadRequest)
 		toJSON(w, okResp{Message: "'addresses' parameter is required"})

--- a/mock_webhooks.go
+++ b/mock_webhooks.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func (ms *MockServer) addWebhookRoutes(r *mux.Router) {
+func (ms *mockServer) addWebhookRoutes(r *mux.Router) {
 	sr := r.PathPrefix("/domains/{domain}/webhooks").Subrouter()
 	sr.HandleFunc("", ms.listWebHooks).Methods(http.MethodGet)
 	sr.HandleFunc("", ms.postWebHook).Methods(http.MethodPost)
@@ -26,11 +26,11 @@ func (ms *MockServer) addWebhookRoutes(r *mux.Router) {
 	}
 }
 
-func (ms *MockServer) listWebHooks(w http.ResponseWriter, _ *http.Request) {
+func (ms *mockServer) listWebHooks(w http.ResponseWriter, _ *http.Request) {
 	toJSON(w, ms.webhooks)
 }
 
-func (ms *MockServer) getWebHook(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) getWebHook(w http.ResponseWriter, r *http.Request) {
 	resp := WebHookResponse{
 		Webhook: UrlOrUrls{
 			Urls: ms.webhooks.Webhooks[mux.Vars(r)["webhook"]].Urls,
@@ -39,7 +39,7 @@ func (ms *MockServer) getWebHook(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, resp)
 }
 
-func (ms *MockServer) postWebHook(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) postWebHook(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		toJSON(w, okResp{Message: err.Error()})
@@ -55,7 +55,7 @@ func (ms *MockServer) postWebHook(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "success"})
 }
 
-func (ms *MockServer) putWebHook(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) putWebHook(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		toJSON(w, okResp{Message: err.Error()})
@@ -71,7 +71,7 @@ func (ms *MockServer) putWebHook(w http.ResponseWriter, r *http.Request) {
 	toJSON(w, okResp{Message: "success"})
 }
 
-func (ms *MockServer) deleteWebHook(w http.ResponseWriter, r *http.Request) {
+func (ms *mockServer) deleteWebHook(w http.ResponseWriter, r *http.Request) {
 	_, ok := ms.webhooks.Webhooks[mux.Vars(r)["webhook"]]
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
## Purpose
To allow users of the `MockServer` to access the internals. This allows testers to verify if their code submitted messages to the mock api correctly.

## Implementation
* `NewMockServer()` now returns an `MockServer` interface, for most users this is a backward compatible change. Only those users who previously stored `MockServer` as a pointer will notice the change. While this is a trade off, the cost of bumping the entire library version to V5 is not really worth such a minor change.