### PR TITLE
add new VerifyAndReturnDomain that returns DomainResponse to comply with mailgun api docs

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -253,6 +253,18 @@ func (mg *MailgunImpl) VerifyDomain(ctx context.Context, domain string) (string,
 	return resp.Domain.State, err
 }
 
+// VerifyAndReturnDomain verifies & retrieves detailed information about the named domain.
+func (mg *MailgunImpl) VerifyAndReturnDomain(ctx context.Context, domain string) (DomainResponse, error) {
+	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + domain + "/verify")
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+
+	payload := newUrlEncodedPayload()
+	var resp DomainResponse
+	err := putResponseFromJSON(ctx, r, payload, &resp)
+	return resp, err
+}
+
 // Optional parameters when creating a domain
 type CreateDomainOptions struct {
 	Password           string

--- a/domains_test.go
+++ b/domains_test.go
@@ -154,6 +154,15 @@ func TestDomainVerify(t *testing.T) {
 	ensure.Nil(t, err)
 }
 
+func TestDomainVerifyAndReturn(t *testing.T) {
+	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg.SetAPIBase(server.URL())
+	ctx := context.Background()
+
+	_, err := mg.VerifyAndReturnDomain(ctx, testDomain)
+	ensure.Nil(t, err)
+}
+
 func TestDomainDkimSelector(t *testing.T) {
 	mg := mailgun.NewMailgun(testDomain, testKey)
 	mg.SetAPIBase(server.URL())


### PR DESCRIPTION
More about the issue here: https://github.com/mailgun/mailgun-go/issues/257

To avoid changing major version, as @thrawn01 proposed, I've introduced the new method, instead of changing the response of `VerifyDomain` method.  