### PR TITLE
Changed url validation

### DIFF
--- a/httphelpers.go
+++ b/httphelpers.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 )
 
-var validURL = regexp.MustCompile(`^/v[2-4].*`)
+var validURL = regexp.MustCompile(`/v[2-4].*`)
 
 type httpRequest struct {
 	URL               string


### PR DESCRIPTION
Because of the base API url validation, it is currently not possible to use a url like `http://localhost/my-proxy/v3`.

My specific use case is to proxy the requests to the Mailgun api via a `https://my-internal-server/mailgun/v3` base. I cannot access the Mailgun API directly in the network but I have access to `my-internal-server`.

Using `https://my-internal-server/mailgun/v3`, I get an error that reads `BaseAPI must end with a /v2, /v3 or /v4`, which it does in my example, but the regex to validate the url is `^/v[2-4].*`, which checks if it _starts_ with the version segment.

Alltough I think this check could be removed completely (a user will notice the wrong URL when the request is sent, like they would notice a wrong username/password) this PR proposes to change the regex to just `/v[2-4].*` so only the presence of a `/v3` segment is validated, no matter where in the URL.

I guess it would be better to validate the URL somewhere where the actual `apiBase` field is available so we could actually validate if it ends in `/v3` but I did not find a way to implement it without breaking the api. The `httpRequest` struct does not know about the `apiBase` but only sees the fully constructed url which makes the validation for a specific format harder.