### PR TITLE
Add support for batch endpoints for adding bounces and complaints

### DIFF
--- a/bounces.go
+++ b/bounces.go
@@ -193,6 +193,18 @@ func (mg *MailgunImpl) AddBounce(ctx context.Context, address, code, error strin
 	return err
 }
 
+// Add Bounces adds a list of bounces to the bounce list
+func (mg *MailgunImpl) AddBounces(ctx context.Context, bounces []Bounce) error {
+	r := newHTTPRequest(generateApiUrl(mg, bouncesEndpoint))
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+
+	payload := newJSONEncodedPayload(bounces)
+
+	_, err := makePostRequest(ctx, r, payload)
+	return err
+}
+
 // DeleteBounce removes all bounces associted with the provided e-mail address.
 func (mg *MailgunImpl) DeleteBounce(ctx context.Context, address string) error {
 	r := newHTTPRequest(generateApiUrl(mg, bouncesEndpoint) + "/" + address)

--- a/spam_complaints.go
+++ b/spam_complaints.go
@@ -164,6 +164,22 @@ func (mg *MailgunImpl) CreateComplaint(ctx context.Context, address string) erro
 	return err
 }
 
+func (mg *MailgunImpl) CreateComplaints(ctx context.Context, addresses []string) error {
+	r := newHTTPRequest(generateApiUrl(mg, complaintsEndpoint))
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+
+	body := make([]map[string]string, len(addresses))
+	for i, addr := range addresses {
+		body[i] = map[string]string{"address": addr}
+	}
+
+	payload := newJSONEncodedPayload(body)
+
+	_, err := makePostRequest(ctx, r, payload)
+	return err
+}
+
 // DeleteComplaint removes a previously registered e-mail address from the list of people who complained
 // of receiving spam from your domain.
 func (mg *MailgunImpl) DeleteComplaint(ctx context.Context, address string) error {


### PR DESCRIPTION
Adds `AddComplaints` and `AddBounces` methods to support the batch mode for the associated endpoints

https://documentation.mailgun.com/en/latest/api-suppressions.html#add-multiple-complaints
https://documentation.mailgun.com/en/latest/api-suppressions.html#add-multiple-bounces