### PR TITLE
[Fix] Setting template in one of the examples

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -849,6 +849,9 @@ func SendTemplateMessage(domain, apiKey string) (string, error) {
 		"Hey %recipient.first%",
 		"If you wish to unsubscribe, click http://mailgun/unsubscribe/%recipient.id%",
 	) // IMPORTANT: No To:-field recipients!
+	
+	// Set template to be applied to this message.
+	m.SetTemplate("my-template")
 
 	m.AddRecipientAndVariables("bob@example.com", map[string]interface{}{
 		"first": "bob",


### PR DESCRIPTION
SendTemplateMessage didn't set a template for the message.