### PR TITLE
Add Event.ClientInfo.Bot field

### DIFF
--- a/events/objects.go
+++ b/events/objects.go
@@ -8,6 +8,7 @@ type ClientInfo struct {
 	DeviceType     string `json:"device-type"`
 	IP             string `json:"ip"`
 	UserAgent      string `json:"user-agent"`
+	Bot            string `json:"bot"`
 }
 
 type GeoLocation struct {

--- a/mock_events.go
+++ b/mock_events.go
@@ -27,6 +27,7 @@ func (ms *mockServer) addEventRoutes(r *mux.Router) {
 			DeviceType:     "desktop",
 			IP:             "8.8.8.8",
 			UserAgent:      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:54.0) Gecko/20100101 Firefox/54.0",
+			Bot:            "",
 		}
 		geoLocation = events.GeoLocation{
 			City:    "San Antonio",


### PR DESCRIPTION
Adding a Bot field to fix the difference between SDK and actual API response.