### PR TITLE
Add missing Total field in temporary failure stats

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -23,6 +23,7 @@ type Delivered struct {
 // Stats on temporary failures
 type Temporary struct {
 	Espblock int `json:"espblock"`
+	Total    int `json:"total"`
 }
 
 // Stats on permanent failures


### PR DESCRIPTION
The temporary failures stats type is missing the `Total` property. This property is present in e.g. the [Java library](https://github.com/mailgun/mailgun-java/blob/641daf873013bab873c6c4e5fee20a9e0fa46b0e/src/main/java/com/mailgun/model/stats/Temporary.java#LL33C19-L33C19). ESPBlocks are only a subset of possible temporary failures, total contains temporary failures for other reasons. Without the property it isn't possible to retrieve all your temporary failures using the Go client.