### PR TITLE
Allow setting preferred reply method to mailing lists

### DIFF
--- a/mailing_lists_test.go
+++ b/mailing_lists_test.go
@@ -100,10 +100,11 @@ func TestMailingLists(t *testing.T) {
 
 	address := randomEmail("list", testDomain)
 	protoList := mailgun.MailingList{
-		Address:     address,
-		Name:        "List1",
-		Description: "A list created by an acceptance test.",
-		AccessLevel: mailgun.AccessLevelMembers,
+		Address:         address,
+		Name:            "List1",
+		Description:     "A list created by an acceptance test.",
+		AccessLevel:     mailgun.AccessLevelMembers,
+		ReplyPreference: mailgun.ReplyPreferenceSender,
 	}
 
 	var countLists = func() int {

--- a/mock_mailing_list.go
+++ b/mock_mailing_list.go
@@ -30,12 +30,13 @@ func (ms *mockServer) addMailingListRoutes(r *mux.Router) {
 
 	ms.mailingList = append(ms.mailingList, MailingListContainer{
 		MailingList: MailingList{
-			AccessLevel:  "everyone",
-			Address:      "foo@mailgun.test",
-			CreatedAt:    RFC2822Time(time.Now().UTC()),
-			Description:  "Mailgun developers list",
-			MembersCount: 1,
-			Name:         "",
+			ReplyPreference: "list",
+			AccessLevel:     "everyone",
+			Address:         "foo@mailgun.test",
+			CreatedAt:       RFC2822Time(time.Now().UTC()),
+			Description:     "Mailgun developers list",
+			MembersCount:    1,
+			Name:            "",
 		},
 		Members: []Member{
 			{
@@ -146,6 +147,9 @@ func (ms *mockServer) updateMailingList(w http.ResponseWriter, r *http.Request) 
 			if r.FormValue("access_level") != "" {
 				ms.mailingList[i].MailingList.AccessLevel = AccessLevel(r.FormValue("access_level"))
 			}
+			if r.FormValue("reply_preference") != "" {
+				ms.mailingList[i].MailingList.ReplyPreference = ReplyPreference(r.FormValue("reply_preference"))
+			}
 			toJSON(w, okResp{Message: "Mailing list member has been updated"})
 			return
 		}
@@ -160,11 +164,12 @@ func (ms *mockServer) createMailingList(w http.ResponseWriter, r *http.Request) 
 
 	ms.mailingList = append(ms.mailingList, MailingListContainer{
 		MailingList: MailingList{
-			CreatedAt:   RFC2822Time(time.Now().UTC()),
-			Name:        r.FormValue("name"),
-			Address:     r.FormValue("address"),
-			Description: r.FormValue("description"),
-			AccessLevel: AccessLevel(r.FormValue("access_level")),
+			CreatedAt:       RFC2822Time(time.Now().UTC()),
+			Name:            r.FormValue("name"),
+			Address:         r.FormValue("address"),
+			Description:     r.FormValue("description"),
+			AccessLevel:     AccessLevel(r.FormValue("access_level")),
+			ReplyPreference: ReplyPreference(r.FormValue("reply_preference")),
 		},
 	})
 	toJSON(w, okResp{Message: "Mailing list has been created"})


### PR DESCRIPTION
The Mailgun API offers the ability to set the preferred reply method to [mailing lists](https://documentation.mailgun.com/en/latest/api-mailinglists.html#mailing-lists), but this is [currently missing](https://pkg.go.dev/github.com/mailgun/mailgun-go#List) in the mailgun-go library.

This PR adds the missing parameter to the mailgun-go library. Specifically, the implementation is based on the existing `AccessLevel` parameter, that is, it adds a new field `ReplyPreference` to the `MailingList` struct, introduces a new `ReplyPreference` datatype, adds support for the parameter in `CreateMailingList` and `UpdateMailingList`, and includes the field in test and mocks.