### PR TITLE
feat: added Send Time Optimization (STO) param

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -103,6 +103,25 @@ func TestSendMGPlainAt(t *testing.T) {
 	})
 }
 
+func TestSendMGSTO(t *testing.T) {
+	if reason := mailgun.SkipNetworkTest(); reason != "" {
+		t.Skip(reason)
+	}
+
+	spendMoney(t, func() {
+		toUser := os.Getenv("MG_EMAIL_TO")
+		mg, err := mailgun.NewMailgunFromEnv()
+		ensure.Nil(t, err)
+
+		ctx := context.Background()
+		m := mg.NewMessage(fromUser, exampleSubject, exampleText, toUser)
+		m.SetSTOPeriod("24h")
+		msg, id, err := mg.Send(ctx, m)
+		ensure.Nil(t, err)
+		t.Log("TestSendMGSTO:MSG(" + msg + "),ID(" + id + ")")
+	})
+}
+
 func TestSendMGHtml(t *testing.T) {
 	if reason := mailgun.SkipNetworkTest(); reason != "" {
 		t.Skip(reason)


### PR DESCRIPTION
Purpose: Add Send Time Optimization (STO) functionality. STO is a Mailgun feature that utilizes machine learning to determine the optimal time to deliver a message to a recipient. The goal is to deliver the message right before the recipient typically checks their email, increasing the chances of engagement and improving overall engagement rates, leading to higher conversions and increased ROI.

Implementation Details: Introduce a new method, SetSTOPeriod, to the Message class, which allows setting the o:deliverytime-optimize-period parameter (https://documentation.mailgun.com/en/latest/api-sending.html#sending). The parameter follows the specification: "Toggles Send Time Optimization (STO) on a per-message basis. The string should be set to the number of hours in [0-9]+h format, with a minimum of 24h and a maximum of 72h." The implemented code performs checks to ensure adherence to this specification.