### PR TITLE
We can set default From in templates, so this should be no longer required when sending templated mails

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -795,10 +795,6 @@ func isValid(m *Message) bool {
 }
 
 func (pm *plainMessage) isValid() bool {
-	if pm.from == "" {
-		return false
-	}
-
 	if !validateStringList(pm.cc, false) {
 		return false
 	}
@@ -810,6 +806,10 @@ func (pm *plainMessage) isValid() bool {
 	if pm.template != "" {
 		// pm.text or pm.html not needed if template is supplied
 		return true
+	}
+
+	if pm.from == "" {
+		return false
 	}
 
 	if pm.text == "" && pm.html == "" {


### PR DESCRIPTION
Since we can add headers to templates, those fields should be optional when sending a mail with a template set. The only header that was required was the 'From'.
In this PR the validating of the from field is placed after checking for a set template.