### PR TITLE
Adding web_scheme as a primary domain attribute

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -27,6 +27,7 @@ type Domain struct {
 	Wildcard     bool        `json:"wildcard"`
 	SpamAction   SpamAction  `json:"spam_action"`
 	State        string      `json:"state"`
+	WebScheme    string      `json:"web_scheme"`
 }
 
 // DNSRecord structures describe intended records to properly configure your domain for use with Mailgun.
@@ -416,6 +417,31 @@ func (mg *MailgunImpl) UpdateDomainTrackingWebPrefix(ctx context.Context, domain
 	payload := newUrlEncodedPayload()
 	payload.addValue("web_prefix", webPrefix)
 	_, err := makePutRequest(ctx, r, payload)
+	return err
+}
+
+// UpdateDomainOptions options for updating a domain
+type UpdateDomainOptions struct {
+	WebScheme string
+}
+
+// UpdateDomain updates a domain's attributes.
+// Currently only the web_scheme update is supported, spam_action and wildcard are to be added.
+func (mg *MailgunImpl) UpdateDomain(ctx context.Context, name string, opts *UpdateDomainOptions) error {
+	r := newHTTPRequest(generatePublicApiUrl(mg, domainsEndpoint) + "/" + name)
+	r.setClient(mg.Client())
+	r.setBasicAuth(basicAuthUser, mg.APIKey())
+
+	payload := newUrlEncodedPayload()
+
+	if opts != nil {
+		if opts.WebScheme != "" {
+			payload.addValue("web_scheme", string(opts.WebScheme))
+		}
+	}
+
+	_, err := makePutRequest(ctx, r, payload)
+
 	return err
 }
 

--- a/domains_test.go
+++ b/domains_test.go
@@ -69,14 +69,19 @@ func TestGetSingleDomainNotExist(t *testing.T) {
 	ensure.DeepEqual(t, ure.Actual, http.StatusNotFound)
 }
 
-func TestAddDeleteDomain(t *testing.T) {
+func TestAddUpdateDeleteDomain(t *testing.T) {
 	mg := mailgun.NewMailgun(testDomain, testKey)
 	mg.SetAPIBase(server.URL())
 	ctx := context.Background()
 
 	// First, we need to add the domain.
 	_, err := mg.CreateDomain(ctx, "mx.mailgun.test",
-		&mailgun.CreateDomainOptions{SpamAction: mailgun.SpamActionTag, Password: "supersecret", WebScheme: "https"})
+		&mailgun.CreateDomainOptions{SpamAction: mailgun.SpamActionTag, Password: "supersecret", WebScheme: "http"})
+	ensure.Nil(t, err)
+
+	// Then, we update it.
+	err = mg.UpdateDomain(ctx, "mx.mailgun.test",
+		&mailgun.UpdateDomainOptions{WebScheme: "https"})
 	ensure.Nil(t, err)
 
 	// Next, we delete it.

--- a/mock_domains.go
+++ b/mock_domains.go
@@ -27,6 +27,7 @@ func (ms *mockServer) addDomainRoutes(r chi.Router) {
 			Wildcard:     true,
 			SpamAction:   SpamActionDisabled,
 			State:        "active",
+			WebScheme:    "http",
 		},
 		Connection: &DomainConnection{
 			RequireTLS:       true,
@@ -84,6 +85,7 @@ func (ms *mockServer) addDomainRoutes(r chi.Router) {
 	r.Get("/domains", ms.listDomains)
 	r.Post("/domains", ms.createDomain)
 	r.Get("/domains/{domain}", ms.getDomain)
+	r.Put("/domains/{domain}", ms.updateDomain)
 	r.Put("/domains/{domain}/verify", ms.getDomain)
 	r.Delete("/domains/{domain}", ms.deleteDomain)
 	//r.Get("/domains/{domain}/credentials", ms.getCredentials)
@@ -168,9 +170,23 @@ func (ms *mockServer) createDomain(w http.ResponseWriter, r *http.Request) {
 			Wildcard:     stringToBool(r.FormValue("wildcard")),
 			SpamAction:   SpamAction(r.FormValue("spam_action")),
 			State:        "active",
+			WebScheme:    "http",
 		},
 	})
 	toJSON(w, okResp{Message: "Domain has been created"})
+}
+
+func (ms *mockServer) updateDomain(w http.ResponseWriter, r *http.Request) {
+	defer ms.mutex.Unlock()
+	ms.mutex.Lock()
+
+	for _, domain := range ms.domainList {
+		if domain.Domain.Name == chi.URLParam(r, "domain") {
+			domain.Domain.WebScheme = r.FormValue("web_scheme")
+		}
+	}
+
+	toJSON(w, okResp{Message: "Domain has been updated"})
 }
 
 func (ms *mockServer) deleteDomain(w http.ResponseWriter, r *http.Request) {

--- a/tags_test.go
+++ b/tags_test.go
@@ -2,7 +2,6 @@ package mailgun_test
 
 import (
 	"context"
-	"log"
 	"testing"
 	"time"
 
@@ -40,7 +39,6 @@ func TestTags(t *testing.T) {
 	var page []mailgun.Tag
 	for it.Next(ctx, &page) {
 		ensure.True(t, len(page) != 0)
-		log.Printf("Tags: %+v\n", page)
 	}
 	ensure.Nil(t, it.Err())
 
@@ -50,7 +48,6 @@ func TestTags(t *testing.T) {
 	var tags []mailgun.Tag
 	for cursor.Next(ctx, &tags) {
 		ensure.DeepEqual(t, len(tags), 1)
-		log.Printf("Tags: %+v\n", tags)
 	}
 	ensure.Nil(t, cursor.Err())
 


### PR DESCRIPTION
Closes #301.

Also removed some unneeded stdout printing from the tag tests.