### PR TITLE
events.DeliveryStatus: expose mx-host and additional fields

### DIFF
--- a/events/objects.go
+++ b/events/objects.go
@@ -71,9 +71,15 @@ type Campaign struct {
 }
 
 type DeliveryStatus struct {
-	Code           int     `json:"code"`
-	AttemptNo      int     `json:"attempt-no"`
-	Description    string  `json:"description"`
-	Message        string  `json:"message"`
-	SessionSeconds float64 `json:"session-seconds"`
+	Code                int     `json:"code"`
+	AttemptNo           int     `json:"attempt-no"`
+	Description         string  `json:"description,omitempty"`
+	Message             string  `json:"message"`
+	SessionSeconds      float64 `json:"session-seconds"`
+	EnhancedCode        string  `json:"enhanced-code,omitempty"`
+	MxHost              string  `json:"mx-host,omitempty"`
+	RetrySeconds        int     `json:"retry-seconds,omitempty"`
+	CertificateVerified *bool   `json:"certificate-verified,omitempty"`
+	TLS                 *bool   `json:"tls,omitempty"`
+	Utf8                *bool   `json:"utf8,omitempty"`
 }


### PR DESCRIPTION
This updates `events.DeliveryStatus` to include additional fields listed in the API docs (and which I observed in practice). I originally noticed that `mx-host` was missing.

Because the boolean fields imply a separate value when they are missing I set them to `*bool` but happy to adjust if there is a style preference. I've marked these new fields as 'omitempty' to indicate they are not always present.

https://documentation.mailgun.com/en/latest/api-events.html#event-structure