### PR TITLE
Fix resource leak from time.NewTicker

### DIFF
--- a/events.go
+++ b/events.go
@@ -277,12 +277,12 @@ func (ep *EventPoller) Poll(ctx context.Context, events *[]Event) bool {
 		ep.it.Paging.Next = currentPage
 
 		// Sleep the rest of our duration
-		tick := time.NewTicker(ep.opts.PollInterval)
+		timer := time.NewTimer(ep.opts.PollInterval)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return false
-		case <-tick.C:
-			tick.Stop()
+		case <-timer.C:
 		}
 	}
 


### PR DESCRIPTION
Currently resources are leaked when `EventPoller.Poll()` returns from the `<-ctx.Done()` branch of the select because a `time.Ticker` must be stopped to release associated resources.

This PR fixes the issue by adding a `.Stop()` call on the branch. The `time.Ticker` is also switched to a `time.Timer` since only one event is used and `time.Timer` is more suitable. Alternatively, it would be enough to just add a `.Stop()` call for `time.Ticker`.