### PR TITLE
mailingListResponse incorrectly set to 'member' instead of 'list'

### DIFF
--- a/mailing_lists.go
+++ b/mailing_lists.go
@@ -52,7 +52,7 @@ type listsResponse struct {
 }
 
 type mailingListResponse struct {
-	MailingList MailingList `json:"member"`
+	MailingList MailingList `json:"list"`
 }
 
 type ListsIterator struct {


### PR DESCRIPTION
### Purpose
When the library was converted to local testing and the use of response structs this struct was incorrectly labeled as `member` instead of `list`. Fixes #314 