### PR TITLE
Correct the VerifyWebhookSignature method to use the WebhookSigningKey as the signature key.

### DIFF
--- a/domains_test.go
+++ b/domains_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
+
 	"github.com/mailgun/mailgun-go/v4"
 )
 
 const (
-	testDomain = "mailgun.test"
-	testKey    = "api-fake-key"
+	testDomain            = "mailgun.test"
+	testKey               = "api-fake-key"
+	testWebhookSigningKey = "webhook-signing-key"
 )
 
 func TestListDomains(t *testing.T) {

--- a/webhooks.go
+++ b/webhooks.go
@@ -121,7 +121,10 @@ type WebhookPayload struct {
 
 // Use this method to parse the webhook signature given as JSON in the webhook response
 func (mg *MailgunImpl) VerifyWebhookSignature(sig Signature) (verified bool, err error) {
-	h := hmac.New(sha256.New, []byte(mg.APIKey()))
+	if mg.WebhookSigningKey() == "" {
+		return false, fmt.Errorf("webhook signing key not set")
+	}
+	h := hmac.New(sha256.New, []byte(mg.WebhookSigningKey()))
 	io.WriteString(h, sig.TimeStamp)
 	io.WriteString(h, sig.Token)
 
@@ -140,7 +143,10 @@ func (mg *MailgunImpl) VerifyWebhookSignature(sig Signature) (verified bool, err
 // Deprecated: Please use the VerifyWebhookSignature() to parse the latest
 // version of WebHooks from mailgun
 func (mg *MailgunImpl) VerifyWebhookRequest(req *http.Request) (verified bool, err error) {
-	h := hmac.New(sha256.New, []byte(mg.APIKey()))
+	if mg.WebhookSigningKey() == "" {
+		return false, fmt.Errorf("webhook signing key not set")
+	}
+	h := hmac.New(sha256.New, []byte(mg.WebhookSigningKey()))
 	io.WriteString(h, req.FormValue("timestamp"))
 	io.WriteString(h, req.FormValue("token"))
 

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/facebookgo/ensure"
+
 	"github.com/mailgun/mailgun-go/v4"
 )
 
@@ -78,10 +79,10 @@ var signedTests = []bool{
 }
 
 func TestVerifyWebhookSignature(t *testing.T) {
-	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg := mailgun.NewMailgun(testDomain, testKey, testWebhookSigningKey)
 
 	for _, v := range signedTests {
-		fields := getSignatureFields(mg.APIKey(), v)
+		fields := getSignatureFields(mg.WebhookSigningKey(), v)
 		sig := mailgun.Signature{
 			TimeStamp: fields["timestamp"],
 			Token:     fields["token"],
@@ -98,10 +99,10 @@ func TestVerifyWebhookSignature(t *testing.T) {
 }
 
 func TestVerifyWebhookRequest_Form(t *testing.T) {
-	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg := mailgun.NewMailgun(testDomain, testKey, testWebhookSigningKey)
 
 	for _, v := range signedTests {
-		fields := getSignatureFields(mg.APIKey(), v)
+		fields := getSignatureFields(mg.WebhookSigningKey(), v)
 		req := buildFormRequest(fields)
 
 		verified, err := mg.VerifyWebhookRequest(req)
@@ -114,10 +115,10 @@ func TestVerifyWebhookRequest_Form(t *testing.T) {
 }
 
 func TestVerifyWebhookRequest_MultipartForm(t *testing.T) {
-	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg := mailgun.NewMailgun(testDomain, testKey, testWebhookSigningKey)
 
 	for _, v := range signedTests {
-		fields := getSignatureFields(mg.APIKey(), v)
+		fields := getSignatureFields(mg.WebhookSigningKey(), v)
 		req := buildMultipartFormRequest(fields)
 
 		verified, err := mg.VerifyWebhookRequest(req)


### PR DESCRIPTION
Correct the VerifyWebhookSignature method to use the WebhookSigningKey as the signature key, instead of incorrectly using the APIKey as the signature key.