### PR TITLE
Store the HTML and TEXT parts of a stored message in the mock server

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -34,23 +34,25 @@ type MockServer interface {
 type mockServer struct {
 	srv *httptest.Server
 
-	domainIPS        []string
-	domainList       []DomainContainer
-	exportList       []Export
-	mailingList      []MailingListContainer
-	routeList        []Route
-	events           []Event
-	templates        []Template
-	templateVersions map[string][]TemplateVersion
-	unsubscribes     []Unsubscribe
-	complaints       []Complaint
-	bounces          []Bounce
-	credentials      []Credential
-	stats            []Stats
-	tags             []Tag
-	subaccountList   []Subaccount
-	webhooks         WebHooksListResponse
-	mutex            sync.Mutex
+	domainIPS         []string
+	domainList        []DomainContainer
+	exportList        []Export
+	mailingList       []MailingListContainer
+	routeList         []Route
+	events            []Event
+	storedMessageHtml map[string]string
+	storedMessageText map[string]string
+	templates         []Template
+	templateVersions  map[string][]TemplateVersion
+	unsubscribes      []Unsubscribe
+	complaints        []Complaint
+	bounces           []Bounce
+	credentials       []Credential
+	stats             []Stats
+	tags              []Tag
+	subaccountList    []Subaccount
+	webhooks          WebHooksListResponse
+	mutex             sync.Mutex
 }
 
 func (ms *mockServer) DomainIPS() []string {

--- a/mock_messages.go
+++ b/mock_messages.go
@@ -16,6 +16,9 @@ func (ms *mockServer) addMessagesRoutes(r chi.Router) {
 	// This path is made up; it could be anything as the storage url could change over time
 	r.Get("/se.storage.url/messages/{id}", ms.getStoredMessages)
 	r.Post("/se.storage.url/messages/{id}", ms.sendStoredMessages)
+
+	ms.storedMessageHtml = make(map[string]string)
+	ms.storedMessageText = make(map[string]string)
 }
 
 // TODO: This implementation doesn't support multiple recipients
@@ -49,6 +52,10 @@ func (ms *mockServer) createMessages(w http.ResponseWriter, r *http.Request) {
 		stored.Flags = events.Flags{
 			IsTestMode: false,
 		}
+
+		ms.storedMessageHtml[id] = r.FormValue("html")
+		ms.storedMessageText[id] = r.FormValue("text")
+
 		ms.mutex.Lock()
 		ms.events = append(ms.events, stored)
 		ms.mutex.Unlock()
@@ -124,6 +131,8 @@ func (ms *mockServer) getStoredMessages(w http.ResponseWriter, r *http.Request) 
 		Sender:     stored.Message.Headers.From,
 		Subject:    stored.Message.Headers.Subject,
 		From:       stored.Message.Headers.From,
+		BodyHtml:   ms.storedMessageHtml[id],
+		BodyPlain:  ms.storedMessageText[id],
 		MessageHeaders: [][]string{
 			{"Sender", stored.Message.Headers.From},
 			{"To", stored.Message.Headers.To},


### PR DESCRIPTION
Mock Server currently drops the HTML and Text portions of the stored email. This allows users to place assertions on the contents of an email. 

For example, my service wants to assert that it has successfully sent an email with a login verification code. This provides the capability to do so.


PTAL - Thanks!