### PR TITLE
Fix webhook signature verification to use the webhook signing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ func main() {
 	// You can find the Private API Key in your Account Menu, under "Settings":
 	// (https://app.mailgun.com/app/account/security)
 	mg := mailgun.NewMailgun("your-domain.com", "private-api-key")
+	mg.SetWebhookSigningKey("webhook-signing-key")
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 

--- a/domains_test.go
+++ b/domains_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	testDomain = "mailgun.test"
-	testKey    = "api-fake-key"
+	testDomain            = "mailgun.test"
+	testKey               = "api-fake-key"
+	testWebhookSigningKey = "webhook-signing-key"
 )
 
 func TestListDomains(t *testing.T) {

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -904,8 +904,9 @@ func UpdateWebhook(domain, apiKey string) error {
 	return mg.UpdateWebhook(ctx, "clicked", []string{"https://your_domain.com/clicked"})
 }
 
-func VerifyWebhookSignature(domain, apiKey, timestamp, token, signature string) (bool, error) {
+func VerifyWebhookSignature(domain, apiKey, webhookSigningKey, timestamp, token, signature string) (bool, error) {
 	mg := mailgun.NewMailgun(domain, apiKey)
+	mg.SetWebhookSigningKey(webhookSigningKey)
 
 	return mg.VerifyWebhookSignature(mailgun.Signature{
 		TimeStamp: timestamp,

--- a/mailgun.go
+++ b/mailgun.go
@@ -345,7 +345,11 @@ func (mg *MailgunImpl) SetClient(c *http.Client) {
 
 // WebhookSigningKey returns the webhook signing key configured for this client
 func (mg *MailgunImpl) WebhookSigningKey() string {
-	return mg.webhookSigningKey
+	key := mg.webhookSigningKey
+	if key == "" {
+		return mg.APIKey()
+	}
+	return key
 }
 
 // SetWebhookSigningKey updates the webhook signing key for this client

--- a/webhooks.go
+++ b/webhooks.go
@@ -123,12 +123,7 @@ type WebhookPayload struct {
 
 // Use this method to parse the webhook signature given as JSON in the webhook response
 func (mg *MailgunImpl) VerifyWebhookSignature(sig Signature) (verified bool, err error) {
-	key := mg.WebhookSigningKey()
-	// For backwards compatibility, fall back to the api key
-	if key == "" {
-		key = mg.APIKey()
-	}
-	h := hmac.New(sha256.New, []byte(key))
+	h := hmac.New(sha256.New, []byte(mg.WebhookSigningKey()))
 
 	_, err = io.WriteString(h, sig.TimeStamp)
 	if err != nil {
@@ -154,12 +149,7 @@ func (mg *MailgunImpl) VerifyWebhookSignature(sig Signature) (verified bool, err
 // Deprecated: Please use the VerifyWebhookSignature() to parse the latest
 // version of WebHooks from mailgun
 func (mg *MailgunImpl) VerifyWebhookRequest(req *http.Request) (verified bool, err error) {
-	key := mg.WebhookSigningKey()
-	// For backwards compatibility, fall back to the api key
-	if key == "" {
-		key = mg.APIKey()
-	}
-	h := hmac.New(sha256.New, []byte(key))
+	h := hmac.New(sha256.New, []byte(mg.WebhookSigningKey()))
 
 	_, err = io.WriteString(h, req.FormValue("timestamp"))
 	if err != nil {

--- a/webhooks.go
+++ b/webhooks.go
@@ -123,7 +123,12 @@ type WebhookPayload struct {
 
 // Use this method to parse the webhook signature given as JSON in the webhook response
 func (mg *MailgunImpl) VerifyWebhookSignature(sig Signature) (verified bool, err error) {
-	h := hmac.New(sha256.New, []byte(mg.APIKey()))
+	key := mg.WebhookSigningKey()
+	// For backwards compatibility, fall back to the api key
+	if key == "" {
+		key = mg.APIKey()
+	}
+	h := hmac.New(sha256.New, []byte(key))
 
 	_, err = io.WriteString(h, sig.TimeStamp)
 	if err != nil {
@@ -149,7 +154,12 @@ func (mg *MailgunImpl) VerifyWebhookSignature(sig Signature) (verified bool, err
 // Deprecated: Please use the VerifyWebhookSignature() to parse the latest
 // version of WebHooks from mailgun
 func (mg *MailgunImpl) VerifyWebhookRequest(req *http.Request) (verified bool, err error) {
-	h := hmac.New(sha256.New, []byte(mg.APIKey()))
+	key := mg.WebhookSigningKey()
+	// For backwards compatibility, fall back to the api key
+	if key == "" {
+		key = mg.APIKey()
+	}
+	h := hmac.New(sha256.New, []byte(key))
 
 	_, err = io.WriteString(h, req.FormValue("timestamp"))
 	if err != nil {

--- a/webhooks_test.go
+++ b/webhooks_test.go
@@ -80,9 +80,10 @@ var signedTests = []bool{
 
 func TestVerifyWebhookSignature(t *testing.T) {
 	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg.SetWebhookSigningKey(testWebhookSigningKey)
 
 	for _, v := range signedTests {
-		fields := getSignatureFields(mg.APIKey(), v)
+		fields := getSignatureFields(mg.WebhookSigningKey(), v)
 		sig := mailgun.Signature{
 			TimeStamp: fields["timestamp"],
 			Token:     fields["token"],
@@ -100,9 +101,10 @@ func TestVerifyWebhookSignature(t *testing.T) {
 
 func TestVerifyWebhookRequest_Form(t *testing.T) {
 	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg.SetWebhookSigningKey(testWebhookSigningKey)
 
 	for _, v := range signedTests {
-		fields := getSignatureFields(mg.APIKey(), v)
+		fields := getSignatureFields(mg.WebhookSigningKey(), v)
 		req := buildFormRequest(fields)
 
 		verified, err := mg.VerifyWebhookRequest(req)
@@ -116,9 +118,10 @@ func TestVerifyWebhookRequest_Form(t *testing.T) {
 
 func TestVerifyWebhookRequest_MultipartForm(t *testing.T) {
 	mg := mailgun.NewMailgun(testDomain, testKey)
+	mg.SetWebhookSigningKey(testWebhookSigningKey)
 
 	for _, v := range signedTests {
-		fields := getSignatureFields(mg.APIKey(), v)
+		fields := getSignatureFields(mg.WebhookSigningKey(), v)
 		req := buildMultipartFormRequest(fields)
 
 		verified, err := mg.VerifyWebhookRequest(req)


### PR DESCRIPTION
Since [the other PR](https://github.com/mailgun/mailgun-go/pull/321) didn't seem to be being addressed, I'm submitting my own. The issues brought up in it have been resolved. Tests pass and it seems to work as directed when testing it as a `replace` in a different project. Please let me know if anything needs addressed, I'd like to have this available as soon as I can get it. Thanks!