### PR TITLE
DE-1457 populate EmailVerification.IsValid field

### DIFF
--- a/email_validation.go
+++ b/email_validation.go
@@ -24,6 +24,7 @@ type EmailVerificationParts struct {
 // See the ValidateEmail method and example for more details.
 type EmailVerification struct {
 	// Indicates whether an email address conforms to IETF RFC standards.
+	// Deprecated: use Risk instead.
 	IsValid bool `json:"is_valid"`
 	// Indicates whether an email address is deliverable.
 	MailboxVerification string `json:"mailbox_verification"`
@@ -44,7 +45,7 @@ type EmailVerification struct {
 	Reason string `json:"reason"`
 	// A list of potential reasons why a specific validation may be unsuccessful. (Available in the v4 response)
 	Reasons []string
-	// Risk assessment for the provided email.
+	// Risk assessment for the provided email: low/medium/high/unknown.
 	Risk string `json:"risk"`
 	// Result
 	Result string `json:"result"`
@@ -60,7 +61,6 @@ type EngagementData struct {
 }
 
 type v4EmailValidationResp struct {
-	IsValid             bool                   `json:"is_valid"`
 	MailboxVerification string                 `json:"mailbox_verification"`
 	Parts               EmailVerificationParts `json:"parts"`
 	Address             string                 `json:"address"`
@@ -195,7 +195,7 @@ func (m *EmailValidatorImpl) validateV4(ctx context.Context, email string, mailB
 		return EmailVerification{}, err
 	}
 	return EmailVerification{
-		IsValid:             res.IsValid,
+		IsValid:             res.Risk == "low",
 		MailboxVerification: res.MailboxVerification,
 		Parts:               res.Parts,
 		Address:             res.Address,

--- a/email_validation_test.go
+++ b/email_validation_test.go
@@ -29,7 +29,7 @@ func TestEmailValidationV4(t *testing.T) {
 	assert.Equal(t, "", ev.Reason)
 	assert.True(t, len(ev.Reasons) != 0)
 	assert.Equal(t, "no-reason", ev.Reasons[0])
-	assert.Equal(t, "unknown", ev.Risk)
+	assert.Equal(t, "low", ev.Risk)
 	assert.Equal(t, "deliverable", ev.Result)
 	assert.Equal(t, "disengaged", ev.Engagement.Behavior)
 	assert.False(t, ev.Engagement.Engaging)

--- a/mock_validation.go
+++ b/mock_validation.go
@@ -26,13 +26,12 @@ func (ms *mockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {
 	var results v4EmailValidationResp
 	parts, err := mail.ParseAddress(r.FormValue("address"))
 	if err == nil {
-		results.IsValid = true
 		results.Parts.Domain = strings.Split(parts.Address, "@")[1]
 		results.Parts.LocalPart = strings.Split(parts.Address, "@")[0]
 		results.Parts.DisplayName = parts.Name
 	}
 	results.Reason = []string{"no-reason"}
-	results.Risk = "unknown"
+	results.Risk = "low"
 	results.Result = "deliverable"
 	results.Engagement = &EngagementData{
 		Engaging: false,

--- a/mock_validation.go
+++ b/mock_validation.go
@@ -24,14 +24,15 @@ func (ms *mockServer) validateEmailV4(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var results v4EmailValidationResp
+	results.Risk = "unknown"
 	parts, err := mail.ParseAddress(r.FormValue("address"))
 	if err == nil {
+		results.Risk = "low"
 		results.Parts.Domain = strings.Split(parts.Address, "@")[1]
 		results.Parts.LocalPart = strings.Split(parts.Address, "@")[0]
 		results.Parts.DisplayName = parts.Name
 	}
 	results.Reason = []string{"no-reason"}
-	results.Risk = "low"
 	results.Result = "deliverable"
 	results.Engagement = &EngagementData{
 		Engaging: false,


### PR DESCRIPTION
IsValid was never populated for v4 validations since https://github.com/mailgun/mailgun-go/pull/218

Fixes #385