### PR TITLE
DE-1497 Remove the need for 'from' when sending messages with a template

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -979,13 +979,16 @@ func (m *PlainMessage) IsValid() bool {
 		return false
 	}
 
-	if m.From() == "" {
-		return false
+	if m.Template() != "" {
+		// m.text or m.html not needed if template is supplied.
+		//
+		// From is not required if sending with a template that has a pre-set From header,
+		// but it will override it if provided.
+		return true
 	}
 
-	if m.Template() != "" {
-		// m.text or m.html not needed if template is supplied
-		return true
+	if m.From() == "" {
+		return false
 	}
 
 	if m.Text() == "" && m.HTML() == "" {


### PR DESCRIPTION
https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/Messages/#tag/Messages/operation/POST-v3--domain-name--messages!path=from&t=request