### PR TITLE
EASY-597: Increase max tag limit to 10 per message

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -19,7 +19,7 @@ import (
 const MaxNumberOfRecipients = 1000
 
 // MaxNumberOfTags represents the maximum number of tags that can be added for a message
-const MaxNumberOfTags = 3
+const MaxNumberOfTags = 10
 
 // CommonMessage structures contain both the message text and the envelope for an e-mail message.
 type CommonMessage struct {

--- a/tags_test.go
+++ b/tags_test.go
@@ -27,6 +27,13 @@ func TestTags(t *testing.T) {
 	require.NoError(t, msg.AddTag("newsletter"))
 	require.NoError(t, msg.AddTag("homer"))
 	require.NoError(t, msg.AddTag("bart"))
+	require.NoError(t, msg.AddTag("marge"))
+	require.NoError(t, msg.AddTag("lisa"))
+	require.NoError(t, msg.AddTag("maggie"))
+	require.NoError(t, msg.AddTag("burns"))
+	require.NoError(t, msg.AddTag("milhouse"))
+	require.NoError(t, msg.AddTag("moe"))
+	require.NoError(t, msg.AddTag("selma"))
 	require.NotNil(t, msg.AddTag("disco-steve"))
 	require.NotNil(t, msg.AddTag("newsletter"))
 


### PR DESCRIPTION
[EASY-597](https://mailgun.atlassian.net/browse/EASY-597):

As part of the broader tags project we are increasing the maximum number of tags per message to 10

[EASY-597]: https://mailgun.atlassian.net/browse/EASY-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ