### PR TITLE
Add ListIPDomains 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea/
+.vscode/
 cmd/mailgun/mailgun
 /.env
 

--- a/domains.go
+++ b/domains.go
@@ -278,3 +278,21 @@ func (mg *Client) UpdateDomain(ctx context.Context, name string, opts *UpdateDom
 
 	return err
 }
+
+// ListIPDomains retrieves a list of domains for the specified IP address.
+func (mg *Client) ListIPDomains(ip string, opts *ListDomainsOptions) *DomainsIterator {
+	var limit int
+	if opts != nil {
+		limit = opts.Limit
+	}
+
+	if limit == 0 {
+		limit = 100
+	}
+	return &DomainsIterator{
+		mg:                  mg,
+		url:                 generateApiUrl(mg, 3, ipsEndpoint) + "/" + ip + "/domains",
+		ListDomainsResponse: mtypes.ListDomainsResponse{TotalCount: -1},
+		limit:               limit,
+	}
+}

--- a/domains_test.go
+++ b/domains_test.go
@@ -108,3 +108,22 @@ func TestDomainVerify(t *testing.T) {
 	_, err = mg.VerifyAndReturnDomain(ctx, testDomain)
 	require.NoError(t, err)
 }
+
+func TestListIPDomains(t *testing.T) {
+	mg := mailgun.NewMailgun(testKey)
+	err := mg.SetAPIBase(server.URL())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	it := mg.ListIPDomains("192.172.1.1", nil)
+	var page []mtypes.Domain
+	for it.Next(ctx, &page) {
+		for _, d := range page {
+			t.Logf("TestListDomains: %#v\n", d)
+		}
+	}
+	t.Logf("TestListDomains: %d domains retrieved\n", it.TotalCount)
+	require.NoError(t, it.Err())
+	assert.True(t, it.TotalCount != 0)
+}

--- a/mailgun.go
+++ b/mailgun.go
@@ -154,6 +154,7 @@ type Mailgun interface {
 	CreateDomain(ctx context.Context, name string, opts *CreateDomainOptions) (mtypes.GetDomainResponse, error)
 	DeleteDomain(ctx context.Context, name string) error
 	VerifyAndReturnDomain(ctx context.Context, name string) (mtypes.GetDomainResponse, error)
+	ListIPDomains(ip string, opts *ListDomainsOptions) *DomainsIterator
 
 	UpdateDomainConnection(ctx context.Context, domain string, dc mtypes.DomainConnection) error
 	GetDomainConnection(ctx context.Context, domain string) (mtypes.DomainConnection, error)

--- a/mocks/mock_domains.go
+++ b/mocks/mock_domains.go
@@ -99,9 +99,50 @@ func (ms *Server) addDomainRoutes(r chi.Router) {
 	r.Get("/v3/domains/{domain}/limits/tag", ms.getTagLimits)
 
 	r.Put("/v3/domains/{domain}/dkim_selector", ms.updateDKIMSelector)
+
+	r.Get("/v3/ips/{ip}/domains", ms.listIPDomains)
 }
 
 func (ms *Server) listDomains(w http.ResponseWriter, r *http.Request) {
+	defer ms.mutex.Unlock()
+	ms.mutex.Lock()
+
+	var list []mtypes.Domain
+	for _, domain := range ms.domainList {
+		list = append(list, domain.Domain)
+	}
+
+	skip := stringToInt(r.FormValue("skip"))
+	limit := stringToInt(r.FormValue("limit"))
+	if limit == 0 {
+		limit = 100
+	}
+
+	if skip > len(list) {
+		skip = len(list)
+	}
+
+	end := limit + skip
+	if end > len(list) {
+		end = len(list)
+	}
+
+	// If we are at the end of the list
+	if skip == end {
+		toJSON(w, mtypes.ListDomainsResponse{
+			TotalCount: len(list),
+			Items:      []mtypes.Domain{},
+		})
+		return
+	}
+
+	toJSON(w, mtypes.ListDomainsResponse{
+		TotalCount: len(list),
+		Items:      list[skip:end],
+	})
+}
+
+func (ms *Server) listIPDomains(w http.ResponseWriter, r *http.Request) {
 	defer ms.mutex.Unlock()
 	ms.mutex.Lock()
 


### PR DESCRIPTION
Adds support for listing domains by IP address https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/IPs/#tag/IPs/operation/GET-v3-ips--ip--domains, with test coverage and mock updates.