### PR TITLE
Update ValidateEmail to use provider_lookup parameter

### DIFF
--- a/mailgun.go
+++ b/mailgun.go
@@ -270,7 +270,7 @@ type Mailgun interface {
 	DeleteTemplateVersion(ctx context.Context, domain, templateName, tag string) error
 	ListTemplateVersions(domain, templateName string, opts *ListOptions) *TemplateVersionsIterator
 
-	ValidateEmail(ctx context.Context, email string, mailBoxVerify bool) (mtypes.ValidateEmailResponse, error)
+	ValidateEmail(ctx context.Context, email string, providerLookup bool) (mtypes.ValidateEmailResponse, error)
 
 	ListAlertsEvents(context.Context, *ListAlertsEventsOptions) (*mtypes.AlertsEventsResponse, error)
 	ListAlerts(context.Context, *ListAlertsOptions) (*mtypes.AlertsSettingsResponse, error)

--- a/mocks/mock_validation.go
+++ b/mocks/mock_validation.go
@@ -26,6 +26,9 @@ func (ms *Server) validateEmailV4(w http.ResponseWriter, r *http.Request) {
 		results.Risk = "low"
 	}
 	results.Reason = []string{"no-reason"}
+	if r.FormValue("provider_lookup") == "true" {
+		results.Reason = []string{"smtp_timeout"}
+	}
 	results.Result = "deliverable"
 	results.Engagement = &mtypes.EngagementData{
 		Engaging: false,

--- a/validation.go
+++ b/validation.go
@@ -10,14 +10,12 @@ import (
 
 // ValidateEmail performs various checks on the email address provided to ensure it's correctly formatted.
 // It may also be used to break an email address into its sub-components.
-// mailBoxVerify controls the "provider_lookup" API parameter: whether Mailgun should reach out
-// to the mailbox provider when its own internal analysis is insufficient. Defaults to true on the API side.
 // https://documentation.mailgun.com/docs/validate/single-valid-ir/
-func (mg *Client) ValidateEmail(ctx context.Context, email string, mailBoxVerify bool) (mtypes.ValidateEmailResponse, error) {
+func (mg *Client) ValidateEmail(ctx context.Context, email string, providerLookup bool) (mtypes.ValidateEmailResponse, error) {
 	r := newHTTPRequest(fmt.Sprintf("%s/v4/address/validate", mg.APIBase()))
 	r.setClient(mg.HTTPClient())
 	r.addParameter("address", email)
-	r.addParameter("provider_lookup", strconv.FormatBool(mailBoxVerify))
+	r.addParameter("provider_lookup", strconv.FormatBool(providerLookup))
 	r.setBasicAuth(basicAuthUser, mg.APIKey())
 
 	var res mtypes.ValidateEmailResponse

--- a/validation.go
+++ b/validation.go
@@ -3,20 +3,21 @@ package mailgun
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/mailgun/mailgun-go/v5/mtypes"
 )
 
 // ValidateEmail performs various checks on the email address provided to ensure it's correctly formatted.
 // It may also be used to break an email address into its sub-components.
-// https://documentation.mailgun.com/docs/inboxready/mailgun-validate/single-valid-ir/
+// mailBoxVerify controls the "provider_lookup" API parameter: whether Mailgun should reach out
+// to the mailbox provider when its own internal analysis is insufficient. Defaults to true on the API side.
+// https://documentation.mailgun.com/docs/validate/single-valid-ir/
 func (mg *Client) ValidateEmail(ctx context.Context, email string, mailBoxVerify bool) (mtypes.ValidateEmailResponse, error) {
 	r := newHTTPRequest(fmt.Sprintf("%s/v4/address/validate", mg.APIBase()))
 	r.setClient(mg.HTTPClient())
 	r.addParameter("address", email)
-	if mailBoxVerify {
-		r.addParameter("mailbox_verification", "true")
-	}
+	r.addParameter("provider_lookup", strconv.FormatBool(mailBoxVerify))
 	r.setBasicAuth(basicAuthUser, mg.APIKey())
 
 	var res mtypes.ValidateEmailResponse

--- a/validation_test.go
+++ b/validation_test.go
@@ -2,9 +2,6 @@ package mailgun_test
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/mailgun/mailgun-go/v5"
@@ -51,26 +48,4 @@ func TestValidateEmail(t *testing.T) {
 		assert.False(t, ev.Engagement.Engaging)
 		assert.False(t, ev.Engagement.IsBot)
 	})
-}
-
-func TestValidateEmailProviderLookupParameter(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		assert.Equal(t, http.MethodGet, req.Method)
-		assert.Equal(t, "/v4/address/validate", req.URL.Path)
-		assert.Equal(t, "foo@mailgun.com", req.FormValue("address"))
-		assert.Equal(t, "true", req.FormValue("provider_lookup"))
-		assert.Empty(t, req.FormValue("mailbox_verification"))
-		_, err := fmt.Fprint(w, `{"address":"foo@mailgun.com","result":"deliverable","risk":"low","reason":[]}`)
-		require.NoError(t, err)
-	}))
-	defer srv.Close()
-
-	mg := mailgun.NewMailgun(testKey)
-	err := mg.SetAPIBase(srv.URL)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-
-	_, err = mg.ValidateEmail(ctx, "foo@mailgun.com", true)
-	require.NoError(t, err)
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -2,6 +2,9 @@ package mailgun_test
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/mailgun/mailgun-go/v5"
@@ -28,4 +31,26 @@ func TestValidateEmail(t *testing.T) {
 	assert.Equal(t, "disengaged", ev.Engagement.Behavior)
 	assert.False(t, ev.Engagement.Engaging)
 	assert.False(t, ev.Engagement.IsBot)
+}
+
+func TestValidateEmailProviderLookupParameter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, http.MethodGet, req.Method)
+		assert.Equal(t, "/v4/address/validate", req.URL.Path)
+		assert.Equal(t, "foo@mailgun.com", req.FormValue("address"))
+		assert.Equal(t, "true", req.FormValue("provider_lookup"))
+		assert.Empty(t, req.FormValue("mailbox_verification"))
+		_, err := fmt.Fprint(w, `{"address":"foo@mailgun.com","result":"deliverable","risk":"low","reason":[]}`)
+		require.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	mg := mailgun.NewMailgun(testKey)
+	err := mg.SetAPIBase(srv.URL)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	_, err = mg.ValidateEmail(ctx, "foo@mailgun.com", true)
+	require.NoError(t, err)
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -19,18 +19,38 @@ func TestValidateEmail(t *testing.T) {
 
 	ctx := context.Background()
 
-	ev, err := mg.ValidateEmail(ctx, "foo@mailgun.com", false)
-	require.NoError(t, err)
+	t.Run("providerLookup=false", func(t *testing.T) {
+		ev, err := mg.ValidateEmail(ctx, "foo@mailgun.com", false)
+		require.NoError(t, err)
 
-	assert.False(t, ev.IsDisposableAddress)
-	assert.False(t, ev.IsRoleAddress)
-	assert.True(t, len(ev.Reason) != 0)
-	assert.Equal(t, "no-reason", ev.Reason[0])
-	assert.Equal(t, "low", ev.Risk)
-	assert.Equal(t, "deliverable", ev.Result)
-	assert.Equal(t, "disengaged", ev.Engagement.Behavior)
-	assert.False(t, ev.Engagement.Engaging)
-	assert.False(t, ev.Engagement.IsBot)
+		assert.False(t, ev.IsDisposableAddress)
+		assert.False(t, ev.IsRoleAddress)
+		require.Len(t, ev.Reason, 1)
+		assert.Equal(t, "no-reason", ev.Reason[0])
+		assert.Equal(t, "low", ev.Risk)
+		assert.Equal(t, "deliverable", ev.Result)
+		assert.Equal(t, "disengaged", ev.Engagement.Behavior)
+		assert.False(t, ev.Engagement.Engaging)
+		assert.False(t, ev.Engagement.IsBot)
+	})
+
+	// When providerLookup (provider_lookup) is true, the mock simulates a mailbox
+	// provider lookup failure by returning "smtp_timeout" as the reason.
+	// https://documentation.mailgun.com/docs/validate/single-valid-ir#reason-explanation
+	t.Run("providerLookup=true", func(t *testing.T) {
+		ev, err := mg.ValidateEmail(ctx, "foo@mailgun.com", true)
+		require.NoError(t, err)
+
+		assert.False(t, ev.IsDisposableAddress)
+		assert.False(t, ev.IsRoleAddress)
+		require.Len(t, ev.Reason, 1)
+		assert.Equal(t, "smtp_timeout", ev.Reason[0])
+		assert.Equal(t, "low", ev.Risk)
+		assert.Equal(t, "deliverable", ev.Result)
+		assert.Equal(t, "disengaged", ev.Engagement.Behavior)
+		assert.False(t, ev.Engagement.Engaging)
+		assert.False(t, ev.Engagement.IsBot)
+	})
 }
 
 func TestValidateEmailProviderLookupParameter(t *testing.T) {


### PR DESCRIPTION
The `mailbox_verification` is a v3 parameter, v4 expects a different one